### PR TITLE
feat(logger): allow multiple strings in .tag()

### DIFF
--- a/packages/utilities/logger.js
+++ b/packages/utilities/logger.js
@@ -8,8 +8,9 @@ class Logger {
     this.tags = tags;
   }
 
-  tag(tag) {
-    return new Logger([...this.tags, tag]);
+  tag(tags) {
+    const newTags = typeof tags === 'string' ? [tags] : tags;
+    return new Logger([...this.tags, ...newTags]);
   }
 
   log(level, ...args) {


### PR DESCRIPTION
This allows multiple tagging without multiple .tag() calls.