### PR TITLE
feat(logger): allow multiple strings in .tag()

### DIFF
--- a/packages/utilities/logger.js
+++ b/packages/utilities/logger.js
@@ -8,8 +8,9 @@ class Logger {
     this.tags = tags;
   }
 
-  tag(tag) {
-    return new Logger([...this.tags, tag]);
+  tag(tags) {
+    const newTags = typeof tags === 'string' ? [tags] : tags;
+    return new Logger([...this.tags, ...newTags]);
   }
 
   log(level, ...args) {

--- a/packages/utilities/package-lock.json
+++ b/packages/utilities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "highoutput-utilities",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highoutput-utilities",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "index.js",
   "dependencies": {
     "debug": "^3.1.0",


### PR DESCRIPTION
This allows multiple tagging without multiple .tag() calls.