### PR TITLE
feat: add transport in connection detail

### DIFF
--- a/packages/amqp/src/index.ts
+++ b/packages/amqp/src/index.ts
@@ -78,6 +78,7 @@ export default class Amqp {
         const details = {
           host: hosts[this.attempts % hosts.length],
           port: ports[this.attempts % ports.length],
+          transport: this.options.transport,
         };
 
         this.attempts++;


### PR DESCRIPTION
Add transport,  because `connection_details` overrides the transport

https://github.com/amqp/rhea/issues/182