### PR TITLE
fix: falsy result leads to timeout

### DIFF
--- a/packages/arque-core/__tests__/connection/local.spec.ts
+++ b/packages/arque-core/__tests__/connection/local.spec.ts
@@ -90,4 +90,21 @@ describe('LocalConnection', () => {
 
     handlers.forEach((handler) => expect(handler.callCount).to.equal(5));
   });
+
+  it('should not timeout when worker resolves into false', async function () {
+    const client = await this.connection.createClient('Boolean');
+
+    const handler = sinon.spy(async () => {
+      await delay(50 + Math.random() * 100);
+
+      return false;
+    });
+
+    await this.connection.createWorker('Boolean', handler);
+
+    const response = await client();
+
+    expect(handler.calledOnce).to.be.true;
+    expect(response).to.equal(false);
+  });
 });

--- a/packages/arque-core/package-lock.json
+++ b/packages/arque-core/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@arque/types": {
-      "version": "1.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@arque/types/-/types-1.0.0-alpha.11.tgz",
-      "integrity": "sha512-EogcplYu2hn8ZcJYpXAzfP3H4fq62CuM5emLtHdhbuaMMfHD4jVWGIJxI6cckz4Oobc/3WAhtcY+sxmtAUWMNw==",
+      "version": "1.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@arque/types/-/types-1.0.0-alpha.12.tgz",
+      "integrity": "sha512-KDBPkL4ZsQ1Dvl2v++3bPaTq4yK/uo2waXS3L/9z4ueostXu/nhymehoGdTkquEg+pWVB1K52ILwjnlteKeiUw==",
       "requires": {
         "@types/node": "^14.11.1"
       }

--- a/packages/arque-core/src/lib/connection/local/index.ts
+++ b/packages/arque-core/src/lib/connection/local/index.ts
@@ -83,7 +83,7 @@ export default class {
           return;
         }
 
-        if (message.result) {
+        if (typeof message.result !== 'undefined') {
           callback.resolve(message.result);
         }
 


### PR DESCRIPTION
Given falsy result value after a worker resolves using `LocalConnection`
```javascript
    const handler = sinon.spy(async () => {
      await delay(50 + Math.random() * 100);

      return false;
    });
```
Arque doesn't return the value back to the client, instead, it throws an error.
```shell
     AppError: Request timed out.
      at /home/megamoth/highoutput/highoutput-library/packages/arque-core/src/lib/connection/local/index.ts:119:17
      at Context.<anonymous> (__tests__/connection/local.spec.ts:105:5)
```

this PR enables handlers to return falsy values back to the client.