### PR TITLE
fix(logger): use `slice` to prevent clearing of tags

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -20,7 +20,7 @@ class Logger {
 
   tag(tags: string | string[]): Logger {
     return new Logger([
-      ...(this.tags.splice(0) as string[]),
+      ...(this.tags.slice(0) as string[]),
       ...(typeof tags === 'string' ? [tags] : tags),
     ]);
   }


### PR DESCRIPTION
Using `.splice(0)` modifies the contents of an array resulting to an empty `[]` array. 
This causes the tags of the original Logger instance to be completely cleared out.