### PR TITLE
refactor: change logs format

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -11,9 +11,9 @@ class Logger {
   private tags: string[] | undefined;
 
   constructor(tags?: string | string[]) {
-      if (tags) {
-        this.tags = (tags instanceof Array)? tags: [tags];
-      }
+    if (tags) {
+      this.tags = (tags instanceof Array)? tags: [tags];
+    }
   }
 
   tag(tags: string | string[]): Logger {
@@ -37,9 +37,9 @@ class Logger {
 
           Object.getOwnPropertyNames(item).forEach(property => {
             (obj as any)[property] = 
-              (typeof (item as any)[property] === 'string')? 
-              (item as any)[property].replace(/\n/g, '\\n'):
-                  (item as any)[property];
+              (typeof (item as any)[property] === 'string') ?
+                (item as any)[property].replace(/\n/g, '\\n') :
+                (item as any)[property];
           });
 
           return obj;

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -56,7 +56,7 @@ class Logger {
         return JSON.stringify({ 
           tags: this.tags, 
           ...(process.env.SERVICE_NAME)? { service: process.env.SERVICE_NAME } : {},
-          ...(typeof item === 'object')? item : { message: item } 
+          message: item, 
         });
       })
       .forEach(item => logger(item));

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -55,7 +55,12 @@ class Logger {
 
         return item;
       })
-      .map(item => JSON.stringify({ tags: this.tags, log: item }))
+      .map(item => {
+        return JSON.stringify({ 
+          tags: this.tags, 
+          ...(typeof item === 'object')? item : { message: item } 
+        });
+      })
       .forEach(item => logger(item));
   }
 

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -36,14 +36,17 @@ class Logger {
           const obj = { message: item.message };
 
           Object.getOwnPropertyNames(item).forEach(property => {
-            (obj as any)[property] = (item as any)[property];
+            (obj as any)[property] = 
+              (typeof (item as any)[property] === 'string')? 
+              (item as any)[property].replace(/\n/g, '\\n'):
+                  (item as any)[property];
           });
 
           return obj;
         }
 
         if (typeof item === 'string') {
-          return item.replace(/\n/, '\\n');
+          return item.replace(/\n/g, '\\n');
         }
 
         if (typeof item === 'number') {

--- a/packages/logger/test/index.spec.ts
+++ b/packages/logger/test/index.spec.ts
@@ -13,6 +13,13 @@ describe('logger', () => {
     logger.silly('Hello world!');
     logger.verbose('Hello world!');
 
+    logger.tag('tag1').tag('tag2').log('info', 'Hello world!');
+    logger.tag('tag1').tag('tag2').info('Hello world!');
+    logger.tag('tag1').tag('tag2').error('Hello world!');
+    logger.tag('tag1').tag('tag2').warn('Hello world!');
+    logger.tag('tag1').tag('tag2').silly('Hello world!');
+    logger.tag('tag1').tag('tag2').verbose('Hello world!');
+
     assert.ok(true);
   });
 
@@ -33,6 +40,13 @@ describe('logger', () => {
     logger.warn({ message: 'Hello world!' });
     logger.silly({ message: 'Hello world!' });
     logger.verbose({ message: 'Hello world!' });
+
+    logger.log('info', { message: { another: 'Hello world!', one: { two: 'Hello world!' } } });
+    logger.info({ message: { another: 'Hello world!', one: { two: 'Hello world!' } } });
+    logger.error({ message: { another: 'Hello world!', one: { two: 'Hello world!' } } });
+    logger.warn({ message: { another: 'Hello world!', one: { two: 'Hello world!' } } });
+    logger.silly({ message: { another: 'Hello world!', one: { two: 'Hello world!' } } });
+    logger.verbose({ message: { another: 'Hello world!', one: { two: 'Hello world!' } } });
 
     assert.ok(true);
   });


### PR DESCRIPTION
Change log format to 
```
  error {"tags":["test","graphql"],"message": {"message":"Hello world!","code":"403"}} 
  error {"tags":["test","graphql"],"service":"account","message": {"message":"Hello world!","code":"403"}}
```

- Service is now fetched from ENV variables
- Make tags optional parameter
- Return tags, service and log as json string