### PR TITLE
Feature/logger serializer

### DIFF
--- a/packages/logger/package-lock.json
+++ b/packages/logger/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@highoutput/logger",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -42,15 +42,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.16.tgz",
       "integrity": "sha512-ydLaGVfQOQ6hI1xK2A5nVh8bl0OGoIfYMxPWHqqYe9bTkWCfqiVvZoh2I/QF2sNSkZzZyROBoTefIEI+PB6iIA==",
       "dev": true
-    },
-    "@types/ramda": {
-      "version": "0.27.64",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.64.tgz",
-      "integrity": "sha512-EDf++ss/JoMiDpvT1MuA8oi88OwpvmqVE+o8Ojm5v/5bdJEPZ6eIQd/XYAeQ0imlwG6Tf0Npfq4Z9w3hAKBk9Q==",
-      "dev": true,
-      "requires": {
-        "ts-toolbelt": "^6.15.1"
-      }
     },
     "ansi-colors": {
       "version": "3.2.3",
@@ -924,11 +915,6 @@
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
-    "ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
-    },
     "readdirp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
@@ -1087,12 +1073,6 @@
           "dev": true
         }
       }
-    },
-    "ts-toolbelt": {
-      "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
-      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
-      "dev": true
     },
     "type-detect": {
       "version": "4.0.8",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@highoutput/logger",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "main": "build/index.js",
   "dependencies": {
     "debug": "^3.1.0",
-    "lru-cache": "^6.0.0",
-    "ramda": "^0.28.0"
+    "lru-cache": "^6.0.0"
   },
   "scripts": {
     "clean": "rimraf build/",
@@ -21,7 +20,6 @@
     "@types/lru-cache": "^5.1.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^17.0.16",
-    "@types/ramda": "^0.27.64",
     "chai": "^4.3.6",
     "mocha": "^7.0.0",
     "rimraf": "^3.0.0",

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,6 +1,6 @@
 import debug, { Debugger } from 'debug';
 import LRU from 'lru-cache';
-import { serialize, deserialize } from './lib/serialize';
+import { serialize } from './lib/serialize';
 
 type Argument = number | string | Error | object | unknown;
 
@@ -46,7 +46,7 @@ class Logger {
           return obj;
         }
 
-        return serialize(deserialize(item));
+        return serialize(item);
       })
       .map((item) => {
         return JSON.stringify({

--- a/packages/logger/src/lib/serialize.ts
+++ b/packages/logger/src/lib/serialize.ts
@@ -59,7 +59,7 @@ export const serialize = (object: any) => {
         return null;
       }
 
-      return Object.keys(object).reduce((arr, key) => {
+      return Object.getOwnPropertyNames(object).reduce((arr, key) => {
         return {
           ...arr,
           [key]: serialize(object[key]),

--- a/packages/logger/src/lib/serialize.ts
+++ b/packages/logger/src/lib/serialize.ts
@@ -1,87 +1,74 @@
-import * as R from 'ramda';
+export const serialize = (object: any) => {
+  try {
+    const type = typeof object;
 
-export function deserialize(object: any): any {
-  const type = typeof object;
-
-  if (
-    type === 'object' &&
-    !(
-      object instanceof Date ||
-      object instanceof Set ||
-      object instanceof Map ||
-      object instanceof Buffer
-    )
-  ) {
-    if (object === null) {
-      return null;
+    if (type === 'string') {
+      return object.replace(/\n/g, '\\n');
     }
 
-    if (object instanceof Array) {
-      return object.map(deserialize);
+    if (type === 'number') {
+      return object.toString();
     }
 
-    if (object.__classObject) {
-      if (object.type === 'Date') {
-        return new Date(object.data);
+    if (type === 'object') {
+      if (object?.__classObject) {
+        if (object.type === 'Date') {
+          return serialize(new Date(object.data));
+        }
+
+        if (object.type === 'Set') {
+          return serialize(object.data);
+        }
+
+        if (object.type === 'Map') {
+          return serialize(object.data);
+        }
+
+        if (object.type === 'Buffer') {
+          return serialize(Buffer.from(object.data, 'base64'));
+        }
       }
 
-      if (object.type === 'Set') {
-        return new Set(object.data.map(deserialize));
+      if (object?._bsontype === 'Binary') {
+        return serialize(object.buffer);
       }
 
-      if (object.type === 'Map') {
-        return new Map(object.data.map(deserialize));
+      if (object instanceof Array) {
+        return object.reduce((arr, val) => {
+          return arr.concat([serialize(val)]);
+        }, []);
       }
 
-      if (object.type === 'Buffer') {
-        return Buffer.from(object.data, 'base64');
+      if (object instanceof Date) {
+        return object.toISOString();
       }
+
+      if (object instanceof Set) {
+        return serialize(Array.from(object));
+      }
+
+      if (object instanceof Map) {
+        return serialize(Array.from(object));
+      }
+
+      if (object instanceof Buffer) {
+        return object.toString('base64');
+      }
+
+      if (object === null) {
+        return null;
+      }
+
+      return Object.keys(object).reduce((arr, key) => {
+        return {
+          ...arr,
+          [key]: serialize(object[key]),
+        };
+      }, {});
     }
 
-    return R.map(deserialize)(object);
+    return object;
+  } catch (error) {
+    return null;
   }
-
-  return object;
-}
-
-export const serialize = (data: any) => {
-  const type = typeof data;
-
-  if (type === 'string') {
-    return data.replace(/\n/g, '\\n');
-  }
-
-  if (type === 'number') {
-    return data.toString();
-  }
-
-  if (type === 'object') {
-    if (data instanceof Array) {
-      return data.map(serialize);
-    }
-
-    if (data instanceof Date) {
-      return data.toISOString();
-    }
-
-    if (data instanceof Set) {
-      return serialize(Array.from(data));
-    }
-
-    if (data instanceof Map) {
-      return serialize(Array.from(data));
-    }
-
-    if (data instanceof Buffer) {
-      return data.toString('base64');
-    }
-
-    if (data === null) {
-      return null;
-    }
-
-    return R.map(serialize)(data);
-  }
-
-  return data;
 };


### PR DESCRIPTION
- Use reduce instead of map to avoid Max stack range error
- Use Object.getOwnPropertyNames instead of Object.keys
