### PR TITLE
feat(api): fix deleteOne to have object as a parameter

### DIFF
--- a/packages/repository/src/repository.ts
+++ b/packages/repository/src/repository.ts
@@ -176,7 +176,7 @@ export class Repository<
   }
 
   async deleteById(id: ObjectId) {
-    await this.model.deleteOne(id.toBuffer());
+    await this.model.deleteOne({ _id: id.toBuffer() });
   }
 
   async deleteMany(filter: FilterQuery<TEntity>) {


### PR DESCRIPTION
## Description

Make use of the object as a parameter with only an `_id`  as the key.
Retain using `deleteOne` since we're not expecting any return