### PR TITLE
queue-requests-to-analytics

### DIFF
--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -78,4 +78,4 @@ Type: `object`
 Any properties relevant to the event. Values with types of `Buffer` or `ObjectID` are serialized into string using [bs58](https://www.npmjs.com/package/bs58).
 
 #### .stop()
-Clears the queue and waits for the pending request to Mixpanel finish.
+Clears the queue and waits for the pending request to Mixpanel to finish.

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -1,0 +1,81 @@
+# analytics
+
+## Install
+```
+npm install @highoutput/analytics
+```
+
+## Usage
+```
+import Analytics from '@highoutput/analytics';
+
+const analytics = new Analytics({
+  project: 'studio',
+  token: 'secret',
+});
+
+analytics.createAccount({
+  accountId: 'unique-id-123',
+  firstname: 'juan',
+  lastname: 'bautista',
+  email: 'juan.bautista@mail.com',
+  created: new Date(),
+});
+
+analytics.createEvent({
+  eventName: 'CREATE_POST',
+  accountId: 'unique-id-123',
+  body: {
+    postType: 'SOME_POST_TYPE',
+    platformUsed: 'web',
+  },
+});
+```
+
+## API
+### Analytics(options)
+Returns a new `analtyics` instance.
+
+#### options
+Type: `object`
+
+##### project
+Type: `string`
+Unique name of your project.
+
+##### token
+Type: `string`
+Token from Mixpanel.
+
+### queue
+`Analytics` instance.
+
+#### .createAccount(options)
+Stores account details to Mixpanel. Only the `accountId` is required. The `firstname`, `lastname`, `email`, and `created` are predefined properties but are not required. If `created` is omitted, it defaults to `new Date()`.
+
+Any additional custom properties can be added. Values with types of `Buffer` or `ObjectID` are serialized into string using [bs58](https://www.npmjs.com/package/bs58).
+
+Note: The corresponding request to Mixpanel is added into a queue.
+
+#### .createEvent(options)
+Stores an event to Mixpanel.
+
+Note: The corresponding request to Mixpanel is added into a queue.
+
+##### options.eventName
+Type: `string`
+
+Name of the event.
+
+##### options.accountId
+Type: `string`
+
+Account associated to the event. Every event in Mixpanel is associated to a specific account.
+
+##### options.body
+Type: `object`
+
+Any properties relevant to the event. Values with types of `Buffer` or `ObjectID` are serialized into string using [bs58](https://www.npmjs.com/package/bs58).
+
+#### .stop()
+Clears the queue and waits for the pending request to Mixpanel finish.

--- a/packages/analytics/package-lock.json
+++ b/packages/analytics/package-lock.json
@@ -9,12 +9,15 @@
       "version": "0.1.8",
       "license": "ISC",
       "dependencies": {
+        "@highoutput/logger": "^0.5.19",
         "@highoutput/object-id": "0.1.8",
         "mixpanel": "0.16.0",
+        "p-queue": "^6.6.2",
         "ramda": "0.28.0",
         "typescript": "4.7.4"
       },
       "devDependencies": {
+        "@highoutput/delay": "^0.2.8",
         "@types/chance": "1.1.3",
         "@types/jest": "28.1.5",
         "@types/node": "18.0.3",
@@ -647,6 +650,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@highoutput/delay": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@highoutput/delay/-/delay-0.2.8.tgz",
+      "integrity": "sha512-g3tSe/XgBCXOkmGAdN6/c5Or7JFhpxT+P+L6+gcOEYSEpVpiYgzGs7Tf70SzZBVOqNVJzUNm3nqG6Z1WLl6pZA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^14.11.1",
+        "ms": "^2.1.2"
+      }
+    },
+    "node_modules/@highoutput/delay/node_modules/@types/node": {
+      "version": "14.18.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.23.tgz",
+      "integrity": "sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==",
+      "dev": true
+    },
+    "node_modules/@highoutput/logger": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@highoutput/logger/-/logger-0.5.19.tgz",
+      "integrity": "sha512-zl3EtKf8Vzn4lcF2plTWEy7lKweUrtR6YzVjaonQ70CSTWDVHm5Nfjsj8mIZrVmkosLuptq1/CYZ5Em1wppz4g==",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "node_modules/@highoutput/logger/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/@highoutput/object-id": {
@@ -2678,6 +2714,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4252,7 +4293,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4508,6 +4548,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -4530,6 +4578,32 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -5566,8 +5640,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.5.1",
@@ -6062,6 +6135,43 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
+        }
+      }
+    },
+    "@highoutput/delay": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@highoutput/delay/-/delay-0.2.8.tgz",
+      "integrity": "sha512-g3tSe/XgBCXOkmGAdN6/c5Or7JFhpxT+P+L6+gcOEYSEpVpiYgzGs7Tf70SzZBVOqNVJzUNm3nqG6Z1WLl6pZA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^14.11.1",
+        "ms": "^2.1.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.18.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.23.tgz",
+          "integrity": "sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==",
+          "dev": true
+        }
+      }
+    },
+    "@highoutput/logger": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@highoutput/logger/-/logger-0.5.19.tgz",
+      "integrity": "sha512-zl3EtKf8Vzn4lcF2plTWEy7lKweUrtR6YzVjaonQ70CSTWDVHm5Nfjsj8mIZrVmkosLuptq1/CYZ5Em1wppz4g==",
+      "requires": {
+        "debug": "^3.1.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
         }
       }
     },
@@ -7588,6 +7698,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -8751,7 +8866,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -8947,6 +9061,11 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
+    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -8963,6 +9082,23 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
+      }
+    },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -9669,8 +9805,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "17.5.1",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -24,12 +24,15 @@
   },
   "homepage": "https://github.com/HighOutputVentures/highoutput-library#readme",
   "dependencies": {
+    "@highoutput/logger": "^0.5.19",
     "@highoutput/object-id": "0.1.8",
     "mixpanel": "0.16.0",
+    "p-queue": "^6.6.2",
     "ramda": "0.28.0",
     "typescript": "4.7.4"
   },
   "devDependencies": {
+    "@highoutput/delay": "^0.2.8",
     "@types/chance": "1.1.3",
     "@types/jest": "28.1.5",
     "@types/node": "18.0.3",

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -65,8 +65,8 @@ export class Analytics {
       ),
     );
 
-    try {
-      this.queue.add(async () => {
+    this.queue.add(async () => {
+      try {
         await new Promise<void>((resolve, reject) => {
           this.driver.people.set(
             params.accountId.toString(),
@@ -88,10 +88,10 @@ export class Analytics {
             },
           );
         });
-      });
-    } catch (error) {
-      logger.tag('createAccount').verbose(error);
-    }
+      } catch (error) {
+        logger.tag('createAccount').verbose(error);
+      }
+    });
   }
 
   createEvent(params: {
@@ -101,8 +101,8 @@ export class Analytics {
   }) {
     if (this.status === 'SHUTTING_DOWN') return;
 
-    try {
-      this.queue.add(async () => {
+    this.queue.add(async () => {
+      try {
         await new Promise<void>((resolve, reject) => {
           this.driver.track(
             params.eventName,
@@ -120,10 +120,10 @@ export class Analytics {
             },
           );
         });
-      });
-    } catch (error) {
-      logger.tag('createEvent').verbose(error);
-    }
+      } catch (error) {
+        logger.tag('createEvent').verbose(error);
+      }
+    });
   }
 
   async stop() {

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -41,9 +41,9 @@ export class Analytics {
   protected queue: PQueue;
   protected status: 'STARTED' | 'SHUTTING_DOWN';
 
-  constructor(params: { project: string }) {
+  constructor(params: { project: string; token: string }) {
     this.project = params.project;
-    this.driver = mixpanel.init(process.env.MIXPANEL_TOKEN || 'secrets');
+    this.driver = mixpanel.init(params.token);
     this.queue = new PQueue({ concurrency: 1 });
     this.status = 'STARTED';
   }

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -121,4 +121,10 @@ export class Analytics {
       }
     });
   }
+
+  async stop() {
+    this.status = 'SHUTTING_DOWN';
+    this.queue.clear();
+    await this.queue.onIdle();
+  }
 }

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -65,8 +65,8 @@ export class Analytics {
       ),
     );
 
-    this.queue.add(async () => {
-      try {
+    try {
+      this.queue.add(async () => {
         await new Promise<void>((resolve, reject) => {
           this.driver.people.set(
             params.accountId.toString(),
@@ -88,10 +88,10 @@ export class Analytics {
             },
           );
         });
-      } catch (error) {
-        logger.tag('createAccount').verbose(error);
-      }
-    });
+      });
+    } catch (error) {
+      logger.tag('createAccount').verbose(error);
+    }
   }
 
   createEvent(params: {
@@ -101,8 +101,8 @@ export class Analytics {
   }) {
     if (this.status === 'SHUTTING_DOWN') return;
 
-    this.queue.add(async () => {
-      try {
+    try {
+      this.queue.add(async () => {
         await new Promise<void>((resolve, reject) => {
           this.driver.track(
             params.eventName,
@@ -120,10 +120,10 @@ export class Analytics {
             },
           );
         });
-      } catch (error) {
-        logger.tag('createEvent').verbose(error);
-      }
-    });
+      });
+    } catch (error) {
+      logger.tag('createEvent').verbose(error);
+    }
   }
 
   async stop() {

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -94,18 +94,22 @@ export class Analytics {
     });
   }
 
-  createEvent(params: { name: string; accountId: string; [key: string]: any }) {
+  createEvent(params: {
+    eventName: string;
+    accountId: string;
+    body: Record<any, any>;
+  }) {
     if (this.status === 'SHUTTING_DOWN') return;
 
     this.queue.add(async () => {
       try {
         await new Promise<void>((resolve, reject) => {
           this.driver.track(
-            params.name,
+            params.eventName,
             {
               $distinct_id: params.accountId,
               meta: { project: this.project },
-              ...serialize(R.omit(['accountId', 'name'], params)),
+              ...serialize(params.body),
             },
             (err) => {
               if (err) {

--- a/packages/analytics/tests/analytics.spec.ts
+++ b/packages/analytics/tests/analytics.spec.ts
@@ -6,7 +6,6 @@ import mixpanel, { Mixpanel } from 'mixpanel';
 import { Analytics } from '../src';
 
 jest.mock('mixpanel');
-jest.setTimeout(10000);
 
 const chance = new Chance();
 

--- a/packages/analytics/tests/analytics.spec.ts
+++ b/packages/analytics/tests/analytics.spec.ts
@@ -14,7 +14,7 @@ function setup(params: { project: string; mockedMixpanelInstance: unknown }) {
   (mixpanel as jest.Mocked<typeof mixpanel>).init.mockImplementation(
     () => params.mockedMixpanelInstance as unknown as Mixpanel,
   );
-  const analytics = new Analytics({ project: params.project });
+  const analytics = new Analytics({ project: params.project, token: 'secret' });
 
   return { analytics };
 }

--- a/packages/analytics/tests/analytics.spec.ts
+++ b/packages/analytics/tests/analytics.spec.ts
@@ -1,9 +1,12 @@
+import EventEmitter from 'events';
+import delay from '@highoutput/delay';
 import { ObjectId } from '@highoutput/object-id';
 import Chance from 'chance';
 import mixpanel, { Mixpanel } from 'mixpanel';
 import { Analytics } from '../src';
 
 jest.mock('mixpanel');
+jest.setTimeout(10000);
 
 const chance = new Chance();
 
@@ -41,7 +44,7 @@ describe('Analytics', () => {
         created: new Date(),
       };
 
-      await analytics.createAccount(accountDetails);
+      analytics.createAccount(accountDetails);
 
       expect(mockedFunction.mock.calls[0][0]).toEqual(
         accountDetails.accountId.toString(),
@@ -78,7 +81,7 @@ describe('Analytics', () => {
         email: chance.email(),
       };
 
-      await analytics.createAccount(accountDetails);
+      analytics.createAccount(accountDetails);
 
       expect(mockedFunction.mock.calls[0][0]).toEqual(
         accountDetails.accountId.toString(),
@@ -120,7 +123,7 @@ describe('Analytics', () => {
         fieldC: ObjectId.from(Buffer.from(chance.string())),
       };
 
-      await analytics.createAccount(accountDetails);
+      analytics.createAccount(accountDetails);
 
       expect(mockedFunction.mock.calls[0][0]).toEqual(
         accountDetails.accountId.toString(),
@@ -139,7 +142,7 @@ describe('Analytics', () => {
       });
     });
 
-    test('should error', async () => {
+    test('should not throw when request encountered an error', async () => {
       const mockedFunction = jest.fn(function (_args, _args2, cb) {
         cb(new Error('error'));
       });
@@ -158,11 +161,33 @@ describe('Analytics', () => {
         accountId: chance.string(),
       };
 
-      try {
-        await analytics.createAccount(accountDetails);
-      } catch (e) {
-        expect(mockedFunction).toThrow();
-      }
+      expect(() => analytics.createAccount(accountDetails)).not.toThrow();
+    });
+
+    test('should not call mixpanel request if status is SHUTTING_DOWN', async () => {
+      const mockedFunction = jest.fn();
+
+      const project = chance.word();
+      const { analytics } = setup({
+        project,
+        mockedMixpanelInstance: {
+          people: {
+            set: mockedFunction,
+          },
+        },
+      });
+
+      const accountDetails = {
+        accountId: chance.string(),
+      };
+
+      await analytics.stop();
+
+      analytics.createAccount(accountDetails);
+
+      await delay('1s');
+
+      expect(mockedFunction).not.toBeCalled();
     });
   });
 
@@ -187,7 +212,7 @@ describe('Analytics', () => {
         fieldB: Buffer.from(chance.string()),
       };
 
-      await analytics.createEvent(eventDetails);
+      analytics.createEvent(eventDetails);
 
       expect(mockedFunction.mock.calls[0][0]).toEqual(
         eventDetails.name.toString(),
@@ -200,7 +225,7 @@ describe('Analytics', () => {
       });
     });
 
-    test('should error', async () => {
+    test('should not throw error when request encountered an error', async () => {
       const mockedFunction = jest.fn(function (_args, _args2, cb) {
         cb(new Error('error'));
       });
@@ -220,11 +245,116 @@ describe('Analytics', () => {
         fieldB: Buffer.from(chance.string()),
       };
 
-      try {
-        await analytics.createEvent(eventDetails);
-      } catch (e) {
-        expect(mockedFunction).toThrow();
-      }
+      expect(() => analytics.createEvent(eventDetails)).not.toThrow();
+    });
+
+    test('should not call mixpanel request if status is SHUTTING_DOWN', async () => {
+      const mockedFunction = jest.fn();
+
+      const project = chance.word();
+      const { analytics } = setup({
+        project,
+        mockedMixpanelInstance: {
+          track: mockedFunction,
+        },
+      });
+
+      const eventDetails = {
+        name: chance.word(),
+        accountId: chance.string(),
+        fieldA: chance.string(),
+        fieldB: Buffer.from(chance.string()),
+      };
+
+      await analytics.stop();
+
+      analytics.createEvent(eventDetails);
+
+      await delay('1s');
+
+      expect(mockedFunction).not.toBeCalled();
+    });
+  });
+
+  describe('#stop', () => {
+    test('should wait for current item in queue to finish', async () => {
+      const callbackWatcher = jest.fn();
+      const mockedFunction = jest.fn(function (_args, _args2, cb) {
+        const eventEmitter = new EventEmitter();
+        const eventName = chance.word();
+        eventEmitter.on(eventName, () => {
+          callbackWatcher();
+          cb();
+        });
+
+        (async () => {
+          await delay('1s');
+          eventEmitter.emit(eventName);
+        })();
+      });
+
+      const project = chance.word();
+      const { analytics } = setup({
+        project,
+        mockedMixpanelInstance: {
+          track: mockedFunction,
+        },
+      });
+
+      analytics.createEvent({
+        name: chance.word(),
+        accountId: chance.string(),
+        fieldA: chance.string(),
+        fieldB: Buffer.from(chance.string()),
+      });
+
+      expect(callbackWatcher).not.toBeCalled();
+      await analytics.stop();
+      expect(callbackWatcher).toBeCalledTimes(1);
+    });
+
+    test('should discard operations waiting in queue', async () => {
+      const callbackWatcher = jest.fn();
+      const mockedFunction = jest.fn(function (_args, _args2, cb) {
+        const eventEmitter = new EventEmitter();
+        const eventName = chance.word();
+        eventEmitter.on(eventName, () => {
+          callbackWatcher();
+          cb();
+        });
+
+        (async () => {
+          await delay('2s');
+          eventEmitter.emit(eventName);
+        })();
+      });
+
+      const project = chance.word();
+      const { analytics } = setup({
+        project,
+        mockedMixpanelInstance: {
+          track: mockedFunction,
+        },
+      });
+
+      analytics.createEvent({
+        name: chance.word(),
+        accountId: chance.string(),
+        fieldA: chance.string(),
+        fieldB: Buffer.from(chance.string()),
+      });
+
+      analytics.createEvent({
+        name: chance.word(),
+        accountId: chance.string(),
+        fieldA: chance.string(),
+        fieldB: Buffer.from(chance.string()),
+      });
+
+      await analytics.stop();
+
+      expect(callbackWatcher).toBeCalledTimes(1);
+      expect(mockedFunction).toBeCalledTimes(1);
     });
   });
 });

--- a/packages/analytics/tests/analytics.spec.ts
+++ b/packages/analytics/tests/analytics.spec.ts
@@ -206,22 +206,24 @@ describe('Analytics', () => {
       });
 
       const eventDetails = {
-        name: chance.word(),
+        eventName: chance.word(),
         accountId: chance.string(),
-        fieldA: chance.string(),
-        fieldB: Buffer.from(chance.string()),
+        body: {
+          fieldA: chance.string(),
+          fieldB: Buffer.from(chance.string()),
+        },
       };
 
       analytics.createEvent(eventDetails);
 
       expect(mockedFunction.mock.calls[0][0]).toEqual(
-        eventDetails.name.toString(),
+        eventDetails.eventName.toString(),
       );
       expect(mockedFunction.mock.calls[0][1]).toEqual({
         $distinct_id: eventDetails.accountId.toString(),
         meta: { project },
-        fieldA: eventDetails.fieldA,
-        fieldB: new ObjectId(eventDetails.fieldB).toString(),
+        fieldA: eventDetails.body.fieldA,
+        fieldB: new ObjectId(eventDetails.body.fieldB).toString(),
       });
     });
 
@@ -239,10 +241,12 @@ describe('Analytics', () => {
       });
 
       const eventDetails = {
-        name: chance.word(),
+        eventName: chance.word(),
         accountId: chance.string(),
-        fieldA: chance.string(),
-        fieldB: Buffer.from(chance.string()),
+        body: {
+          fieldA: chance.string(),
+          fieldB: Buffer.from(chance.string()),
+        },
       };
 
       expect(() => analytics.createEvent(eventDetails)).not.toThrow();
@@ -260,10 +264,9 @@ describe('Analytics', () => {
       });
 
       const eventDetails = {
-        name: chance.word(),
+        eventName: chance.word(),
         accountId: chance.string(),
-        fieldA: chance.string(),
-        fieldB: Buffer.from(chance.string()),
+        body: { fieldA: chance.string(), fieldB: Buffer.from(chance.string()) },
       };
 
       await analytics.stop();
@@ -302,10 +305,12 @@ describe('Analytics', () => {
       });
 
       analytics.createEvent({
-        name: chance.word(),
+        eventName: chance.word(),
         accountId: chance.string(),
-        fieldA: chance.string(),
-        fieldB: Buffer.from(chance.string()),
+        body: {
+          fieldA: chance.string(),
+          fieldB: Buffer.from(chance.string()),
+        },
       });
 
       expect(callbackWatcher).not.toBeCalled();
@@ -338,17 +343,21 @@ describe('Analytics', () => {
       });
 
       analytics.createEvent({
-        name: chance.word(),
+        eventName: chance.word(),
         accountId: chance.string(),
-        fieldA: chance.string(),
-        fieldB: Buffer.from(chance.string()),
+        body: {
+          fieldA: chance.string(),
+          fieldB: Buffer.from(chance.string()),
+        },
       });
 
       analytics.createEvent({
-        name: chance.word(),
+        eventName: chance.word(),
         accountId: chance.string(),
-        fieldA: chance.string(),
-        fieldB: Buffer.from(chance.string()),
+        body: {
+          fieldA: chance.string(),
+          fieldB: Buffer.from(chance.string()),
+        },
       });
 
       await analytics.stop();


### PR DESCRIPTION
### Main Update
- Put requests to Mixpanel in a queue.
- Add a `.stop()` method to clear the queue and wait for the pending request to finish.

### Other updates
- Restructure the parameters of `.createEvent` method. Add `params.body` to hold the fields for the event body.
- Require `token` parameters in `Analytics` constructor.
- Add documentation.