### PR TITLE
analytics library updates

### DIFF
--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -14,14 +14,19 @@ const analytics = new Analytics({
   token: 'secret',
 });
 
-analytics.createAccount({
+// Create or update user
+analytics.setAccount({
   accountId: 'unique-id-123',
-  firstname: 'juan',
-  lastname: 'bautista',
-  email: 'juan.bautista@mail.com',
-  created: new Date(),
+  body: {
+    firstname: 'juan',
+    lastname: 'bautista',
+    email: 'juan.bautista@mail.com',
+    created: new Date(),
+  }
 });
 
+// Create an event.
+// Omit `accountId` if event does not need to be associated to user.
 analytics.createEvent({
   eventName: 'CREATE_POST',
   accountId: 'unique-id-123',
@@ -50,8 +55,14 @@ Token from Mixpanel.
 ### queue
 `Analytics` instance.
 
-#### .createAccount(options)
-Stores account details to Mixpanel. Only the `accountId` is required. The `firstname`, `lastname`, `email`, and `created` are predefined properties but are not required. If `created` is omitted, it defaults to `new Date()`.
+#### .setAccount(options)
+Create or update user details to. Only the `accountId` is required.
+
+##### options.accountId
+Unique identifier of the user. In Mixpanel, this will appear as Distinct ID.
+
+##### options.body
+Details of the user. The `firstname`, `lastname`, `email`, and `created` are predefined properties but are not required. If `created` is omitted, it defaults to `new Date()`.
 
 Any additional custom properties can be added. Values with types of `Buffer` or `ObjectID` are serialized into string using [bs58](https://www.npmjs.com/package/bs58).
 
@@ -67,10 +78,10 @@ Type: `string`
 
 Name of the event.
 
-##### options.accountId
+##### options.accountId?
 Type: `string`
 
-Account associated to the event. Every event in Mixpanel is associated to a specific account.
+User associated to the event. If omitted, the event created will not be associated to any user.
 
 ##### options.body
 Type: `object`

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -48,7 +48,7 @@ export class Analytics {
     this.status = 'STARTED';
   }
 
-  createAccount(params: {
+  setAccount(params: {
     accountId: string;
     body: {
       firstname?: string;

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -50,20 +50,15 @@ export class Analytics {
 
   createAccount(params: {
     accountId: string;
-    firstname?: string;
-    lastname?: string;
-    email?: string;
-    created?: Date;
-    [key: string]: any;
+    body: {
+      firstname?: string;
+      lastname?: string;
+      email?: string;
+      created?: Date;
+      [key: string]: any;
+    };
   }) {
     if (this.status === 'SHUTTING_DOWN') return;
-
-    const extraFields = serialize(
-      R.omit(
-        ['accountId', 'firstname', 'lastname', 'email', 'created'],
-        params,
-      ),
-    );
 
     this.queue.add(async () => {
       try {
@@ -73,11 +68,16 @@ export class Analytics {
             {
               $distinct_id: params.accountId.toString(),
               meta: { project: this.project },
-              $first_name: params.firstname,
-              $last_name: params.lastname,
-              $email: params.email,
-              $created: params.created ?? new Date(),
-              ...extraFields,
+              $first_name: params.body.firstname,
+              $last_name: params.body.lastname,
+              $email: params.body.email,
+              $created: params.body.created ?? new Date(),
+              ...serialize(
+                R.omit(
+                  ['accountId', 'firstname', 'lastname', 'email', 'created'],
+                  params.body,
+                ),
+              ),
             },
             (err) => {
               if (err) {

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -96,7 +96,7 @@ export class Analytics {
 
   createEvent(params: {
     eventName: string;
-    accountId: string;
+    accountId?: string;
     body: Record<any, any>;
   }) {
     if (this.status === 'SHUTTING_DOWN') return;

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -107,7 +107,7 @@ export class Analytics {
           this.driver.track(
             params.eventName,
             {
-              $distinct_id: params.accountId,
+              distinct_id: params.accountId,
               meta: { project: this.project },
               ...serialize(params.body),
             },

--- a/packages/analytics/tests/analytics.spec.ts
+++ b/packages/analytics/tests/analytics.spec.ts
@@ -203,7 +203,7 @@ describe('Analytics', () => {
   });
 
   describe('#createEvent', () => {
-    test('should create an event', async () => {
+    test('should create an event with an accountId', async () => {
       const mockedFunction = jest.fn(function (_args, _args2, cb) {
         cb();
       });
@@ -232,6 +232,39 @@ describe('Analytics', () => {
       );
       expect(mockedFunction.mock.calls[0][1]).toEqual({
         distinct_id: eventDetails.accountId.toString(),
+        meta: { project },
+        fieldA: eventDetails.body.fieldA,
+        fieldB: new ObjectId(eventDetails.body.fieldB).toString(),
+      });
+    });
+
+    test('should create an event without accountId', async () => {
+      const mockedFunction = jest.fn(function (_args, _args2, cb) {
+        cb();
+      });
+
+      const project = chance.word();
+      const { analytics } = setup({
+        project,
+        mockedMixpanelInstance: {
+          track: mockedFunction,
+        },
+      });
+
+      const eventDetails = {
+        eventName: chance.word(),
+        body: {
+          fieldA: chance.string(),
+          fieldB: Buffer.from(chance.string()),
+        },
+      };
+
+      analytics.createEvent(eventDetails);
+
+      expect(mockedFunction.mock.calls[0][0]).toEqual(
+        eventDetails.eventName.toString(),
+      );
+      expect(mockedFunction.mock.calls[0][1]).toEqual({
         meta: { project },
         fieldA: eventDetails.body.fieldA,
         fieldB: new ObjectId(eventDetails.body.fieldB).toString(),

--- a/packages/analytics/tests/analytics.spec.ts
+++ b/packages/analytics/tests/analytics.spec.ts
@@ -37,10 +37,12 @@ describe('Analytics', () => {
 
       const accountDetails = {
         accountId: chance.string(),
-        firstname: chance.first(),
-        lastname: chance.last(),
-        email: chance.email(),
-        created: new Date(),
+        body: {
+          firstname: chance.first(),
+          lastname: chance.last(),
+          email: chance.email(),
+          created: new Date(),
+        },
       };
 
       analytics.createAccount(accountDetails);
@@ -51,10 +53,10 @@ describe('Analytics', () => {
       expect(mockedFunction.mock.calls[0][1]).toEqual({
         $distinct_id: accountDetails.accountId.toString(),
         meta: { project },
-        $first_name: accountDetails.firstname,
-        $last_name: accountDetails.lastname,
-        $email: accountDetails.email,
-        $created: accountDetails.created,
+        $first_name: accountDetails.body.firstname,
+        $last_name: accountDetails.body.lastname,
+        $email: accountDetails.body.email,
+        $created: accountDetails.body.created,
       });
     });
 
@@ -75,9 +77,11 @@ describe('Analytics', () => {
 
       const accountDetails = {
         accountId: chance.string(),
-        firstname: chance.first(),
-        lastname: chance.last(),
-        email: chance.email(),
+        body: {
+          firstname: chance.first(),
+          lastname: chance.last(),
+          email: chance.email(),
+        },
       };
 
       analytics.createAccount(accountDetails);
@@ -91,9 +95,9 @@ describe('Analytics', () => {
         accountDetails.accountId.toString(),
       );
       expect(expectedData.meta.project).toEqual(project);
-      expect(expectedData.$first_name).toEqual(accountDetails.firstname);
-      expect(expectedData.$last_name).toEqual(accountDetails.lastname);
-      expect(expectedData.$email).toEqual(accountDetails.email);
+      expect(expectedData.$first_name).toEqual(accountDetails.body.firstname);
+      expect(expectedData.$last_name).toEqual(accountDetails.body.lastname);
+      expect(expectedData.$email).toEqual(accountDetails.body.email);
       expect(expectedData.$created).toBeDefined();
     });
 
@@ -113,13 +117,15 @@ describe('Analytics', () => {
 
       const accountDetails = {
         accountId: chance.string(),
-        firstname: chance.first(),
-        lastname: chance.last(),
-        email: chance.email(),
-        created: new Date(),
-        fieldA: Buffer.from('fieldA'),
-        fieldB: chance.string(),
-        fieldC: ObjectId.from(Buffer.from(chance.string())),
+        body: {
+          firstname: chance.first(),
+          lastname: chance.last(),
+          email: chance.email(),
+          created: new Date(),
+          fieldA: Buffer.from('fieldA'),
+          fieldB: chance.string(),
+          fieldC: ObjectId.from(Buffer.from(chance.string())),
+        },
       };
 
       analytics.createAccount(accountDetails);
@@ -131,13 +137,13 @@ describe('Analytics', () => {
       expect(mockedFunction.mock.calls[0][1]).toEqual({
         $distinct_id: accountDetails.accountId.toString(),
         meta: { project },
-        $first_name: accountDetails.firstname,
-        $last_name: accountDetails.lastname,
-        $email: accountDetails.email,
-        $created: accountDetails.created,
-        fieldA: new ObjectId(accountDetails.fieldA).toString(),
-        fieldB: accountDetails.fieldB,
-        fieldC: accountDetails.fieldC.toString(),
+        $first_name: accountDetails.body.firstname,
+        $last_name: accountDetails.body.lastname,
+        $email: accountDetails.body.email,
+        $created: accountDetails.body.created,
+        fieldA: new ObjectId(accountDetails.body.fieldA).toString(),
+        fieldB: accountDetails.body.fieldB,
+        fieldC: accountDetails.body.fieldC.toString(),
       });
     });
 
@@ -158,6 +164,9 @@ describe('Analytics', () => {
 
       const accountDetails = {
         accountId: chance.string(),
+        body: {
+          fieldA: Buffer.from('fieldA'),
+        },
       };
 
       expect(() => analytics.createAccount(accountDetails)).not.toThrow();
@@ -178,6 +187,9 @@ describe('Analytics', () => {
 
       const accountDetails = {
         accountId: chance.string(),
+        body: {
+          fieldA: Buffer.from('fieldA'),
+        },
       };
 
       await analytics.stop();

--- a/packages/analytics/tests/analytics.spec.ts
+++ b/packages/analytics/tests/analytics.spec.ts
@@ -231,7 +231,7 @@ describe('Analytics', () => {
         eventDetails.eventName.toString(),
       );
       expect(mockedFunction.mock.calls[0][1]).toEqual({
-        $distinct_id: eventDetails.accountId.toString(),
+        distinct_id: eventDetails.accountId.toString(),
         meta: { project },
         fieldA: eventDetails.body.fieldA,
         fieldB: new ObjectId(eventDetails.body.fieldB).toString(),

--- a/packages/analytics/tests/analytics.spec.ts
+++ b/packages/analytics/tests/analytics.spec.ts
@@ -19,7 +19,7 @@ function setup(params: { project: string; mockedMixpanelInstance: unknown }) {
 }
 
 describe('Analytics', () => {
-  describe('#createAccount', () => {
+  describe('#setAccount', () => {
     test('should create an account', async () => {
       const mockedFunction = jest.fn(function (_args, _args2, cb) {
         cb();
@@ -45,7 +45,7 @@ describe('Analytics', () => {
         },
       };
 
-      analytics.createAccount(accountDetails);
+      analytics.setAccount(accountDetails);
 
       expect(mockedFunction.mock.calls[0][0]).toEqual(
         accountDetails.accountId.toString(),
@@ -84,7 +84,7 @@ describe('Analytics', () => {
         },
       };
 
-      analytics.createAccount(accountDetails);
+      analytics.setAccount(accountDetails);
 
       expect(mockedFunction.mock.calls[0][0]).toEqual(
         accountDetails.accountId.toString(),
@@ -128,7 +128,7 @@ describe('Analytics', () => {
         },
       };
 
-      analytics.createAccount(accountDetails);
+      analytics.setAccount(accountDetails);
 
       expect(mockedFunction.mock.calls[0][0]).toEqual(
         accountDetails.accountId.toString(),
@@ -169,7 +169,7 @@ describe('Analytics', () => {
         },
       };
 
-      expect(() => analytics.createAccount(accountDetails)).not.toThrow();
+      expect(() => analytics.setAccount(accountDetails)).not.toThrow();
     });
 
     test('should not call mixpanel request if status is SHUTTING_DOWN', async () => {
@@ -194,7 +194,7 @@ describe('Analytics', () => {
 
       await analytics.stop();
 
-      analytics.createAccount(accountDetails);
+      analytics.setAccount(accountDetails);
 
       await delay('1s');
 


### PR DESCRIPTION
### Fix
- Use `distinct_id` instead of `$distinct_id`.

### Non breaking API changes
- Set `params.accountId` of `.createEvent` method to optional since Mixpanel does not require events to be associated with a user.

### Breaking API changes
- Wrap user details parameters of method `createAccount` into `params.body`.
- Rename method `createAccount` to `setAccount` as it is used for both creating and updating a user.