### PR TITLE
fix(email-auth): retrieve FORBIDDEN error code correctly

### DIFF
--- a/packages/email-auth/src/email-auth-server.ts
+++ b/packages/email-auth/src/email-auth-server.ts
@@ -69,7 +69,7 @@ export class EmailAuthServer {
             });
           }
           catch(error: any) {
-            if (error.code === 'FORBIDDEN') {
+            if (error.extensions.code === 'FORBIDDEN') {
               res.status(403);
               res.send({
                 error: {


### PR DESCRIPTION
Changed `error.code === 'FORBIDDEN'` to `error.extensions.code === 'FORBIDDEN'`