### PR TITLE
chore(billing): update GET /secret endpoint

### DIFF
--- a/packages/billing/__tests__/get-secret.spec.ts
+++ b/packages/billing/__tests__/get-secret.spec.ts
@@ -5,7 +5,7 @@ import BillingServer from '../src/billing-server';
 import { setup, teardown } from './fixture';
 
 describe('GET /secret', () => {
-  test('request is valid -> should return intent details', async () => {
+  test('when there is no existing intent -> should return client secret', async () => {
     const authorizationAdapter = {
       authorize: jest.fn(async () =>
         Promise.resolve({ id: Buffer.from(faker.datatype.uuid()) }),
@@ -15,17 +15,17 @@ describe('GET /secret', () => {
       stripeSecretKey:
         'sk_test_51LWeDVGrNXva3DrphN3qGT3dnhh2bAoNZ7O80w4XpMEbBlMeLul10aMS7a41PXZHl8vOpcDI6JZ7KoNTSBFyV9r800kV6WzTLo',
       authorizationAdapter,
-      config: './test-config.json',
+      config: './__tests__/test-config.json',
     });
     const ctx = await setup(billingServer);
     const expected = {
-      id: `seti_${faker.random.alphaNumeric(24)}`,
       client_secret: `seti_${faker.random.alphaNumeric(
         24,
       )}_secret_${faker.random.alphaNumeric(24)}`,
-      status: 'requires_payment_method',
-      customer: `cus_${faker.random.alphaNumeric(24)}`,
     };
+    nock(/stripe.com/)
+      .get(/\/v1\/setup_intents/)
+      .reply(200, { data: [] });
     nock(/stripe.com/)
       .post(/\/v1\/setup_intents/)
       .reply(200, expected);
@@ -33,6 +33,7 @@ describe('GET /secret', () => {
     await ctx.request
       .get('/secret')
       .set('Authorization', 'Bearer Token')
+      .query({ userId: `cus_${faker.random.alphaNumeric(24)}` })
       .expect('Content-Type', /json/)
       .expect(200)
       .expect((res) => {

--- a/packages/billing/src/billing-server.ts
+++ b/packages/billing/src/billing-server.ts
@@ -51,9 +51,12 @@ export default class BillingServer {
         return;
       }
 
-      const [, token] = (authHeader as string).split(' ');
+      const [scheme, token] = (authHeader as string).split(' ');
 
-      const user = await authorizationAdapter.authorize(token);
+      const user = await authorizationAdapter.authorize({
+        scheme: scheme as 'Bearer',
+        parameters: token,
+      });
 
       if (R.isNil(user)) {
         res.set('Content-Type', 'application/json');

--- a/packages/billing/src/interfaces/authorization-adapter.ts
+++ b/packages/billing/src/interfaces/authorization-adapter.ts
@@ -3,5 +3,8 @@ type User = {
 };
 
 export interface AuthorizationAdapter {
-  authorize(ctx: unknown): Promise<User | null>;
+  authorize(params: {
+    scheme: 'Bearer';
+    parameters: string;
+  }): Promise<User | null>;
 }

--- a/packages/billing/src/lib/route-handlers.ts
+++ b/packages/billing/src/lib/route-handlers.ts
@@ -27,12 +27,23 @@ async function getTiersHandler(req: Request) {
   return config.tiers;
 }
 
-async function getClientSecret(_req: Request) {
-  const setupIntent = await stripe.setupIntents.create({
+async function getClientSecret(req: Request) {
+  const { userId } = req.params;
+
+  const intentList = await stripe.setupIntents.list({
+    customer: userId,
+  });
+
+  if (!R.isEmpty(intentList.data)) {
+    const [intent] = intentList.data;
+    return R.pick(['client_secret'], intent);
+  }
+
+  const intent = await stripe.setupIntents.create({
     payment_method_types: ['card'],
   });
 
-  return R.pick(['id', 'status', 'client_secret', 'customer'], setupIntent);
+  return R.pick(['client_secret'], intent);
 }
 
 export const handlerMapper = {


### PR DESCRIPTION
## Description
Updated GET /secret endpoint to check for existing intents. Parameters for `AuthorizationAdapter#authorize` is also revamped.

## Breaking
- [ ] Breaking changes
- [x] Non-breaking changes
