### PR TITLE
feat(billing): initialize webhook endpoint

### DIFF
--- a/packages/billing-next/src/interfaces/stripe.provider.ts
+++ b/packages/billing-next/src/interfaces/stripe.provider.ts
@@ -13,6 +13,7 @@ export type Value = {
 export enum ValueType {
   'BILLING_PORTAL_CONFIGURATION' = 'stripeBillingPortalConfiguration',
   'WEBHOOK_SIGNING_SECRET' = 'stripeWebhookSigningSecret',
+  'WEBHOOK_ENDPOINT_CONFIGURATION' = 'stripeWebhookEndpointConfiguration',
 }
 
 export interface IStripeProviderStorageAdapter {
@@ -28,4 +29,5 @@ export interface IStripeProviderStorageAdapter {
 export interface IStripeProvider {
   initializeTiers(): Promise<void>;
   initializeCustomerPortal(): Promise<void>;
+  initializeWebhookEndpoint(): Promise<void>;
 }

--- a/packages/billing-next/src/providers/config.provider.ts
+++ b/packages/billing-next/src/providers/config.provider.ts
@@ -34,6 +34,11 @@ const schema: JTDSchemaType<Config> = {
         },
       },
     },
+    webhook: {
+      properties: {
+        url: { type: 'string' },
+      },
+    },
   },
 };
 

--- a/packages/billing-next/src/typings.ts
+++ b/packages/billing-next/src/typings.ts
@@ -16,7 +16,12 @@ export type CustomerPortalConfig = {
   };
 };
 
+export type WebhookConfig = {
+  url: string;
+};
+
 export type Config = {
   tiers: TierConfig[];
   customerPortal: CustomerPortalConfig;
+  webhook: WebhookConfig;
 };


### PR DESCRIPTION
## Description
Implemented `StripeProvider#initializeWebhookEndpoint`. This includes related tests.

## Breaking
- [ ] Breaking changes
- [x] Non-breaking changes