### PR TITLE
feat(billing): retrieve client secret

### DIFF
--- a/packages/billing-next/__tests__/get-secret.test.ts
+++ b/packages/billing-next/__tests__/get-secret.test.ts
@@ -1,0 +1,105 @@
+import nock from 'nock';
+import { MongooseStripeProdiverStorageAdapter } from '../src/adapters/mongoose-stripe-provider-storage.adapter';
+import { JwtAuthorizationAdapter } from '../src/adapters/jwt-authorization.adapter';
+import { setup, teardown } from './fixture';
+import { generateFakeId, IdType } from './helpers/generate-fake-id';
+import { generateToken } from './helpers/generate-token';
+import { BillingServer } from '../src';
+
+describe('GET /secret', () => {
+  test.concurrent(
+    'request is authorized and customer exists -> should return client secret',
+    async () => {
+      const ctx = await setup();
+
+      const storageAdapter = new MongooseStripeProdiverStorageAdapter(
+        ctx.mongoose,
+      );
+
+      const customer = {
+        id: generateFakeId(IdType.USER),
+        stripeCustomer: generateFakeId(IdType.CUSTOMER),
+      };
+      const token = generateToken({ sub: customer.id }, 'secret');
+
+      await storageAdapter.insertCustomer(customer);
+
+      const billingServer = new BillingServer({
+        stripeSecretKey:
+          'sk_test_51LWeDVGrNXva3DrphN3qGT3dnhh2bAoNZ7O80w4XpMEbBlMeLul10aMS7a41PXZHl8vOpcDI6JZ7KoNTSBFyV9r800kV6WzTLo',
+        configFilePath: './__tests__/assets/config.json',
+        endpointSigningSecret: 'whsec_T1sWT0N2rHkaFNG8EDgJfryNdlg6r2MW',
+        stripeProviderStorageAdapter: storageAdapter,
+        authorizationAdapter: new JwtAuthorizationAdapter({ secret: 'secret' }),
+      });
+
+      ctx.app.use(billingServer.expressMiddleware());
+
+      const clientSecret = generateFakeId(IdType.SETUP_INTENT_SECRET);
+
+      nock(/stripe.com/)
+        .get(/\/v1\/setup_intents/)
+        .reply(200, { data: [] })
+        .post(/\/v1\/setup_intents/)
+        .reply(200, { client_secret: clientSecret });
+
+      await ctx.request
+        .get('/secret')
+        .set('Authorization', `Bearer ${token}`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toMatchObject({ secret: clientSecret });
+        });
+
+      await teardown(ctx);
+    },
+    10000,
+  );
+
+  test.concurrent(
+    'request is authorized and customer does not exist -> should return client secret',
+    async () => {
+      const ctx = await setup();
+
+      const customer = {
+        id: generateFakeId(IdType.USER),
+        stripeCustomer: generateFakeId(IdType.CUSTOMER),
+      };
+      const token = generateToken({ sub: customer.id }, 'secret');
+
+      const billingServer = new BillingServer({
+        stripeSecretKey:
+          'sk_test_51LWeDVGrNXva3DrphN3qGT3dnhh2bAoNZ7O80w4XpMEbBlMeLul10aMS7a41PXZHl8vOpcDI6JZ7KoNTSBFyV9r800kV6WzTLo',
+        configFilePath: './__tests__/assets/config.json',
+        endpointSigningSecret: 'whsec_T1sWT0N2rHkaFNG8EDgJfryNdlg6r2MW',
+        stripeProviderStorageAdapter: new MongooseStripeProdiverStorageAdapter(
+          ctx.mongoose,
+        ),
+        authorizationAdapter: new JwtAuthorizationAdapter({ secret: 'secret' }),
+      });
+
+      ctx.app.use(billingServer.expressMiddleware());
+
+      const clientSecret = generateFakeId(IdType.SETUP_INTENT_SECRET);
+
+      nock(/stripe.com/)
+        .post(/\/v1\/customers/)
+        .reply(200, { id: customer.stripeCustomer })
+        .post(/\/v1\/setup_intents/)
+        .reply(200, { client_secret: clientSecret });
+
+      await ctx.request
+        .get('/secret')
+        .set('Authorization', `Bearer ${token}`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toMatchObject({ secret: clientSecret });
+        });
+
+      await teardown(ctx);
+    },
+    10000,
+  );
+});

--- a/packages/billing-next/__tests__/helpers/generate-fake-id.ts
+++ b/packages/billing-next/__tests__/helpers/generate-fake-id.ts
@@ -1,0 +1,20 @@
+/* eslint-disable no-shadow */
+import { faker } from '@faker-js/faker';
+
+export enum IdType {
+  'USER' = 0,
+  'CUSTOMER',
+  'SETUP_INTENT_SECRET',
+}
+
+export function generateFakeId(idType: IdType) {
+  const idMapper = {
+    0: faker.datatype.uuid(),
+    1: `cus_${faker.random.alphaNumeric(12)}`,
+    2: `seti_${faker.random.alphaNumeric(
+      12,
+    )}_secret_${faker.random.alphaNumeric(12)}`,
+  };
+
+  return idMapper[idType];
+}

--- a/packages/billing-next/__tests__/helpers/generate-token.ts
+++ b/packages/billing-next/__tests__/helpers/generate-token.ts
@@ -1,0 +1,9 @@
+import jwt from 'jsonwebtoken';
+
+type Payload = {
+  sub: string;
+} & Record<string, string>;
+
+export function generateToken(payload: Payload, secret: string) {
+  return jwt.sign(payload, secret);
+}

--- a/packages/billing-next/src/adapters/mongoose-stripe-provider-storage.adapter.ts
+++ b/packages/billing-next/src/adapters/mongoose-stripe-provider-storage.adapter.ts
@@ -2,6 +2,7 @@
 import { Connection, Document, Model, Schema } from 'mongoose';
 import R from 'ramda';
 import {
+  Customer,
   IStripeProviderStorageAdapter,
   Tier,
   Value,
@@ -23,6 +24,8 @@ export class MongooseStripeProdiverStorageAdapter
   #tierModel: Model<TierDocument>;
 
   #valueModel: Model<Value>;
+
+  #customerModel: Model<Customer>;
 
   constructor(connection: Connection) {
     this.#tierModel = connection.model<TierDocument>(
@@ -54,6 +57,22 @@ export class MongooseStripeProdiverStorageAdapter
         value: {
           type: String,
           required: true,
+        },
+      }),
+    );
+
+    this.#customerModel = connection.model(
+      'Customer',
+      new Schema<Customer>({
+        id: {
+          type: String,
+          required: true,
+          unique: true,
+        },
+        stripeCustomer: {
+          type: String,
+          required: true,
+          unique: true,
         },
       }),
     );
@@ -105,5 +124,13 @@ export class MongooseStripeProdiverStorageAdapter
 
   async updateValue(id: ValueType, value: string) {
     await this.#valueModel.findOneAndUpdate({ id }, { value });
+  }
+
+  async findCustomer(id: string) {
+    return this.#customerModel.findOne({ id }).lean();
+  }
+
+  async insertCustomer(customer: Customer) {
+    await this.#customerModel.create(customer);
   }
 }

--- a/packages/billing-next/src/interfaces/api.provider.ts
+++ b/packages/billing-next/src/interfaces/api.provider.ts
@@ -12,7 +12,7 @@ export type Response<T = unknown> = {
 
 export interface IApiProvider {
   getTiers(): Promise<Response<TierConfig[]>>;
-  // getSecret(params: Request): Promise<Response<{ secret: string }>>;
+  getSecret(params: Request): Promise<Response<string>>;
   // getSubscription(params: Request): Promise<Response>;
   // putSubscription(params: Request<{ tier: string }>): Promise<Response>;
 }

--- a/packages/billing-next/src/interfaces/stripe.provider.ts
+++ b/packages/billing-next/src/interfaces/stripe.provider.ts
@@ -10,6 +10,11 @@ export type Value = {
   value: string;
 };
 
+export type Customer = {
+  id: string;
+  stripeCustomer: string;
+};
+
 export enum ValueType {
   'BILLING_PORTAL_CONFIGURATION' = 'stripeBillingPortalConfiguration',
   'WEBHOOK_SIGNING_SECRET' = 'stripeWebhookSigningSecret',
@@ -24,6 +29,12 @@ export interface IStripeProviderStorageAdapter {
   insertValue(value: Value): Promise<void>;
   findValue(id: ValueType): Promise<Value | null>;
   updateValue(id: ValueType, value: string): Promise<void>;
+  findCustomer(id: string): Promise<Customer | null>;
+  insertCustomer(customer: Customer): Promise<void>;
+  // updateCustomer(
+  //   id: string,
+  //   params: Partial<Omit<Customer, 'id'>>,
+  // ): Promise<void>;
 }
 
 export interface IStripeProvider {

--- a/packages/billing-next/src/providers/express-api.provider.test.ts
+++ b/packages/billing-next/src/providers/express-api.provider.test.ts
@@ -1,0 +1,199 @@
+import { Container } from 'inversify';
+import { generateFakeConfig } from '../../__tests__/helpers/generate-fake-config';
+import { IApiProvider } from '../interfaces/api.provider';
+import { ExpressApiProvider } from './express-api.provider';
+import { TYPES } from '../types';
+import {
+  generateFakeId,
+  IdType,
+} from '../../__tests__/helpers/generate-fake-id';
+
+describe('ExpressApiProvider', () => {
+  describe('#getSecret', () => {
+    test.concurrent(
+      'customer exists with no intent -> should create and return new intent',
+      async () => {
+        const config = generateFakeConfig();
+
+        const container = new Container();
+
+        const clientSecret = generateFakeId(IdType.SETUP_INTENT_SECRET);
+
+        const StripeMock = {
+          setupIntents: {
+            list: jest.fn(async () => Promise.resolve({ data: [] })),
+            create: jest.fn(async () =>
+              Promise.resolve({ client_secret: clientSecret }),
+            ),
+          },
+        };
+
+        const customer = {
+          id: generateFakeId(IdType.USER),
+          stripeCustomer: generateFakeId(IdType.CUSTOMER),
+        };
+
+        const StripeProviderStorageAdapterMock = {
+          findCustomer: jest.fn(async () => Promise.resolve(customer)),
+        };
+
+        container.bind(TYPES.Stripe).toConstantValue(StripeMock);
+        container.bind(TYPES.ConfigProvider).toConstantValue({
+          config,
+        });
+        container
+          .bind(TYPES.StripeProviderStorageAdapter)
+          .toConstantValue(StripeProviderStorageAdapterMock);
+        container.bind(TYPES.ApiProvider).to(ExpressApiProvider);
+
+        const provider = container.get<IApiProvider>(TYPES.ApiProvider);
+
+        const response = await provider.getSecret({ user: customer.id });
+
+        expect(StripeProviderStorageAdapterMock.findCustomer).toBeCalledWith(
+          customer.id,
+        );
+        expect(StripeMock.setupIntents.list).toBeCalledWith({
+          customer: customer.stripeCustomer,
+        });
+        expect(StripeMock.setupIntents.create).toBeCalledWith({
+          payment_method_types: ['card'],
+          customer: customer.stripeCustomer,
+        });
+        expect(response).toEqual({
+          status: 200,
+          body: {
+            secret: clientSecret,
+          },
+        });
+      },
+    );
+
+    test.concurrent(
+      'customer exists with intent -> should return existing intent',
+      async () => {
+        const config = generateFakeConfig();
+
+        const container = new Container();
+
+        const clientSecret = generateFakeId(IdType.SETUP_INTENT_SECRET);
+
+        const StripeMock = {
+          setupIntents: {
+            list: jest.fn(async () =>
+              Promise.resolve({ data: [{ client_secret: clientSecret }] }),
+            ),
+          },
+        };
+
+        const customer = {
+          id: generateFakeId(IdType.USER),
+          stripeCustomer: generateFakeId(IdType.CUSTOMER),
+        };
+
+        const StripeProviderStorageAdapterMock = {
+          findCustomer: jest.fn(async () => Promise.resolve(customer)),
+        };
+
+        container.bind(TYPES.Stripe).toConstantValue(StripeMock);
+        container.bind(TYPES.ConfigProvider).toConstantValue({
+          config,
+        });
+        container
+          .bind(TYPES.StripeProviderStorageAdapter)
+          .toConstantValue(StripeProviderStorageAdapterMock);
+        container.bind(TYPES.ApiProvider).to(ExpressApiProvider);
+
+        const provider = container.get<IApiProvider>(TYPES.ApiProvider);
+
+        const response = await provider.getSecret({ user: customer.id });
+
+        expect(StripeProviderStorageAdapterMock.findCustomer).toBeCalledWith(
+          customer.id,
+        );
+        expect(StripeMock.setupIntents.list).toBeCalledWith({
+          customer: customer.stripeCustomer,
+        });
+        expect(response).toEqual({
+          status: 200,
+          body: {
+            secret: clientSecret,
+          },
+        });
+      },
+    );
+    test.concurrent(
+      'customer does not exist -> should create customer and return new intent',
+      async () => {
+        const config = generateFakeConfig();
+
+        const container = new Container();
+
+        const clientSecret = generateFakeId(IdType.SETUP_INTENT_SECRET);
+
+        const customer = {
+          id: generateFakeId(IdType.USER),
+          stripeCustomer: generateFakeId(IdType.CUSTOMER),
+        };
+
+        const StripeMock = {
+          setupIntents: {
+            list: jest.fn(async () =>
+              Promise.resolve({ data: [{ client_secret: clientSecret }] }),
+            ),
+            create: jest.fn(async () =>
+              Promise.resolve({
+                client_secret: clientSecret,
+              }),
+            ),
+          },
+          customers: {
+            create: jest.fn(async () =>
+              Promise.resolve({ id: customer.stripeCustomer }),
+            ),
+          },
+        };
+
+        const StripeProviderStorageAdapterMock = {
+          findCustomer: jest.fn(async () => Promise.resolve(null)),
+          insertCustomer: jest.fn(async () => Promise.resolve()),
+        };
+
+        container.bind(TYPES.Stripe).toConstantValue(StripeMock);
+        container.bind(TYPES.ConfigProvider).toConstantValue({
+          config,
+        });
+        container
+          .bind(TYPES.StripeProviderStorageAdapter)
+          .toConstantValue(StripeProviderStorageAdapterMock);
+        container.bind(TYPES.ApiProvider).to(ExpressApiProvider);
+
+        const provider = container.get<IApiProvider>(TYPES.ApiProvider);
+
+        const response = await provider.getSecret({ user: customer.id });
+
+        expect(StripeProviderStorageAdapterMock.findCustomer).toBeCalledWith(
+          customer.id,
+        );
+        expect(StripeMock.customers.create).toBeCalledWith({
+          metadata: {
+            id: customer.id,
+          },
+        });
+        expect(StripeProviderStorageAdapterMock.insertCustomer).toBeCalledWith(
+          customer,
+        );
+        expect(StripeMock.setupIntents.create).toBeCalledWith({
+          payment_method_types: ['card'],
+          customer: customer.stripeCustomer,
+        });
+        expect(response).toEqual({
+          status: 200,
+          body: {
+            secret: clientSecret,
+          },
+        });
+      },
+    );
+  });
+});

--- a/packages/billing-next/src/providers/express-api.provider.ts
+++ b/packages/billing-next/src/providers/express-api.provider.ts
@@ -1,18 +1,22 @@
 /* eslint-disable no-useless-constructor */
 import { injectable, inject } from 'inversify';
-import { IApiProvider, Response } from '../interfaces/api.provider';
+import Stripe from 'stripe';
+import R from 'ramda';
+import { IApiProvider, Request, Response } from '../interfaces/api.provider';
 import { TYPES } from '../types';
-// import { IStripeProviderStorageAdapter } from '../interfaces/stripe.provider';
+import { IStripeProviderStorageAdapter } from '../interfaces/stripe.provider';
 import { IConfigProvider } from '../interfaces/config.provider';
 import { TierConfig } from '../typings';
 
 @injectable()
 export class ExpressApiProvider implements IApiProvider {
   constructor(
-    @inject(TYPES.ConfigProvider) private configProvider: IConfigProvider, // @inject(TYPES.StripeProviderStorageAdapter) // private storageAdapter: IStripeProviderStorageAdapter,
+    @inject(TYPES.Stripe) private stripe: Stripe,
+    @inject(TYPES.ConfigProvider) private configProvider: IConfigProvider,
+    @inject(TYPES.StripeProviderStorageAdapter)
+    private storageAdapter: IStripeProviderStorageAdapter,
   ) {}
 
-  // eslint-disable-next-line class-methods-use-this
   async getTiers() {
     return {
       status: 200,
@@ -20,5 +24,52 @@ export class ExpressApiProvider implements IApiProvider {
         data: this.configProvider.config.tiers,
       },
     } as Response<TierConfig[]>;
+  }
+
+  async getSecret(params: Request) {
+    const { user } = params;
+
+    const customer = await this.storageAdapter.findCustomer(user);
+    let customerId: string;
+
+    if (customer) {
+      const intentList = await this.stripe.setupIntents.list({
+        customer: customer.stripeCustomer,
+      });
+      customerId = customer.stripeCustomer;
+
+      if (!R.isEmpty(intentList.data)) {
+        const [intent] = intentList.data;
+        return {
+          status: 200,
+          body: {
+            secret: intent.client_secret,
+          },
+        } as Response<string>;
+      }
+    } else {
+      const stripeCustomer = await this.stripe.customers.create({
+        metadata: {
+          id: user,
+        },
+      });
+      await this.storageAdapter.insertCustomer({
+        id: user,
+        stripeCustomer: stripeCustomer.id,
+      });
+      customerId = stripeCustomer.id;
+    }
+
+    const intent = await this.stripe.setupIntents.create({
+      payment_method_types: ['card'],
+      customer: customerId,
+    });
+
+    return {
+      status: 200,
+      body: {
+        secret: intent.client_secret,
+      },
+    } as Response<string>;
   }
 }


### PR DESCRIPTION
## Description
Added `GET /secret` to retrieve the client secret required to setup a payment method. This includes related unit and integration tests.

## Breaking
- [ ] Breaking changes
- [x] Non-breaking changes