### PR TITLE
feat(billing): retrieve a user's subscription

### DIFF
--- a/packages/billing-next/__tests__/get-secret.test.ts
+++ b/packages/billing-next/__tests__/get-secret.test.ts
@@ -49,7 +49,7 @@ describe('GET /secret', () => {
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((res) => {
-          expect(res.body).toMatchObject({ secret: clientSecret });
+          expect(res.body.secret).toEqual(clientSecret);
         });
 
       await teardown(ctx);
@@ -95,7 +95,7 @@ describe('GET /secret', () => {
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((res) => {
-          expect(res.body).toMatchObject({ secret: clientSecret });
+          expect(res.body.secret).toEqual(clientSecret);
         });
 
       await teardown(ctx);

--- a/packages/billing-next/__tests__/get-subscription.test.ts
+++ b/packages/billing-next/__tests__/get-subscription.test.ts
@@ -1,0 +1,86 @@
+import { MongooseStripeProdiverStorageAdapter } from '../src/adapters/mongoose-stripe-provider-storage.adapter';
+import { JwtAuthorizationAdapter } from '../src/adapters/jwt-authorization.adapter';
+import { setup, teardown } from './fixture';
+import { generateFakeId, IdType } from './helpers/generate-fake-id';
+import { generateToken } from './helpers/generate-token';
+import { BillingServer } from '../src';
+
+describe('GET /subscription', () => {
+  test.concurrent(
+    'request is authorized and user is subscribed -> should return subscription data',
+    async () => {
+      const ctx = await setup();
+
+      const storageAdapter = new MongooseStripeProdiverStorageAdapter(
+        ctx.mongoose,
+      );
+
+      const subscription = {
+        id: generateFakeId(IdType.USER),
+        stripeSubscription: generateFakeId(IdType.SUBSCRIPTION),
+        tier: 'Starter',
+        quantity: 1,
+      };
+      const token = generateToken({ sub: subscription.id }, 'secret');
+
+      await storageAdapter.insertSubscription(subscription);
+
+      const billingServer = new BillingServer({
+        stripeSecretKey:
+          'sk_test_51LWeDVGrNXva3DrphN3qGT3dnhh2bAoNZ7O80w4XpMEbBlMeLul10aMS7a41PXZHl8vOpcDI6JZ7KoNTSBFyV9r800kV6WzTLo',
+        configFilePath: './__tests__/assets/config.json',
+        endpointSigningSecret: 'whsec_T1sWT0N2rHkaFNG8EDgJfryNdlg6r2MW',
+        stripeProviderStorageAdapter: storageAdapter,
+        authorizationAdapter: new JwtAuthorizationAdapter({ secret: 'secret' }),
+      });
+
+      ctx.app.use(billingServer.expressMiddleware());
+
+      await ctx.request
+        .get('/subscription')
+        .set('Authorization', `Bearer ${token}`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data).toMatchObject(subscription);
+        });
+
+      await teardown(ctx);
+    },
+    10000,
+  );
+
+  test.concurrent(
+    'request is authorized and user is not subscribed -> should return null',
+    async () => {
+      const ctx = await setup();
+      const user = generateFakeId(IdType.USER);
+      const token = generateToken({ sub: user }, 'secret');
+
+      const billingServer = new BillingServer({
+        stripeSecretKey:
+          'sk_test_51LWeDVGrNXva3DrphN3qGT3dnhh2bAoNZ7O80w4XpMEbBlMeLul10aMS7a41PXZHl8vOpcDI6JZ7KoNTSBFyV9r800kV6WzTLo',
+        configFilePath: './__tests__/assets/config.json',
+        endpointSigningSecret: 'whsec_T1sWT0N2rHkaFNG8EDgJfryNdlg6r2MW',
+        stripeProviderStorageAdapter: new MongooseStripeProdiverStorageAdapter(
+          ctx.mongoose,
+        ),
+        authorizationAdapter: new JwtAuthorizationAdapter({ secret: 'secret' }),
+      });
+
+      ctx.app.use(billingServer.expressMiddleware());
+
+      await ctx.request
+        .get('/subscription')
+        .set('Authorization', `Bearer ${token}`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data).toBeNull();
+        });
+
+      await teardown(ctx);
+    },
+    10000,
+  );
+});

--- a/packages/billing-next/__tests__/helpers/generate-fake-id.ts
+++ b/packages/billing-next/__tests__/helpers/generate-fake-id.ts
@@ -5,6 +5,7 @@ export enum IdType {
   'USER' = 0,
   'CUSTOMER',
   'SETUP_INTENT_SECRET',
+  'SUBSCRIPTION',
 }
 
 export function generateFakeId(idType: IdType) {
@@ -14,6 +15,7 @@ export function generateFakeId(idType: IdType) {
     2: `seti_${faker.random.alphaNumeric(
       12,
     )}_secret_${faker.random.alphaNumeric(12)}`,
+    3: `sub_${faker.random.alphaNumeric(24)}`,
   };
 
   return idMapper[idType];

--- a/packages/billing-next/src/adapters/mongoose-stripe-provider-storage.adapter.ts
+++ b/packages/billing-next/src/adapters/mongoose-stripe-provider-storage.adapter.ts
@@ -4,6 +4,7 @@ import R from 'ramda';
 import {
   Customer,
   IStripeProviderStorageAdapter,
+  Subscription,
   Tier,
   Value,
   ValueType,
@@ -26,6 +27,8 @@ export class MongooseStripeProdiverStorageAdapter
   #valueModel: Model<Value>;
 
   #customerModel: Model<Customer>;
+
+  #subscriptionModel: Model<Subscription>;
 
   constructor(connection: Connection) {
     this.#tierModel = connection.model<TierDocument>(
@@ -73,6 +76,30 @@ export class MongooseStripeProdiverStorageAdapter
           type: String,
           required: true,
           unique: true,
+        },
+      }),
+    );
+
+    this.#subscriptionModel = connection.model(
+      'Subscription',
+      new Schema<Subscription>({
+        id: {
+          type: String,
+          required: true,
+          unique: true,
+        },
+        stripeSubscription: {
+          type: String,
+          required: true,
+          unique: true,
+        },
+        tier: {
+          type: String,
+          required: true,
+        },
+        quantity: {
+          type: Number,
+          default: 1,
         },
       }),
     );
@@ -132,5 +159,13 @@ export class MongooseStripeProdiverStorageAdapter
 
   async insertCustomer(customer: Customer) {
     await this.#customerModel.create(customer);
+  }
+
+  async insertSubscription(subscription: Subscription) {
+    await this.#subscriptionModel.create(subscription);
+  }
+
+  async findSubscription(id: string) {
+    return this.#subscriptionModel.findOne({ id }).lean();
   }
 }

--- a/packages/billing-next/src/index.ts
+++ b/packages/billing-next/src/index.ts
@@ -93,6 +93,9 @@ export class BillingServer {
         case R.test(/GET/, method) && R.test(/secret/, endpoint):
           data = await expressApi.getSecret({ user: (user as User).id });
           break;
+        case R.test(/GET/, method) && R.test(/subscription/, endpoint):
+          data = await expressApi.getSubscription({ user: (user as User).id });
+          break;
         default:
           data = null as never;
           break;

--- a/packages/billing-next/src/interfaces/api.provider.ts
+++ b/packages/billing-next/src/interfaces/api.provider.ts
@@ -13,6 +13,6 @@ export type Response<T = unknown> = {
 export interface IApiProvider {
   getTiers(): Promise<Response<TierConfig[]>>;
   getSecret(params: Request): Promise<Response<string>>;
-  // getSubscription(params: Request): Promise<Response>;
+  getSubscription(params: Request): Promise<Response>;
   // putSubscription(params: Request<{ tier: string }>): Promise<Response>;
 }

--- a/packages/billing-next/src/interfaces/stripe.provider.ts
+++ b/packages/billing-next/src/interfaces/stripe.provider.ts
@@ -15,6 +15,13 @@ export type Customer = {
   stripeCustomer: string;
 };
 
+export type Subscription = {
+  id: string;
+  stripeSubscription: string;
+  tier: string;
+  quantity: number;
+};
+
 export enum ValueType {
   'BILLING_PORTAL_CONFIGURATION' = 'stripeBillingPortalConfiguration',
   'WEBHOOK_SIGNING_SECRET' = 'stripeWebhookSigningSecret',
@@ -31,10 +38,8 @@ export interface IStripeProviderStorageAdapter {
   updateValue(id: ValueType, value: string): Promise<void>;
   findCustomer(id: string): Promise<Customer | null>;
   insertCustomer(customer: Customer): Promise<void>;
-  // updateCustomer(
-  //   id: string,
-  //   params: Partial<Omit<Customer, 'id'>>,
-  // ): Promise<void>;
+  insertSubscription(subscription: Subscription): Promise<void>;
+  findSubscription(id: string): Promise<Subscription | null>;
 }
 
 export interface IStripeProvider {

--- a/packages/billing-next/src/providers/express-api.provider.ts
+++ b/packages/billing-next/src/providers/express-api.provider.ts
@@ -72,4 +72,16 @@ export class ExpressApiProvider implements IApiProvider {
       },
     } as Response<string>;
   }
+
+  async getSubscription(params: Request) {
+    const { user } = params;
+    const subscription = await this.storageAdapter.findSubscription(user);
+
+    return {
+      status: 200,
+      body: {
+        data: subscription,
+      },
+    } as Response;
+  }
 }


### PR DESCRIPTION
## Description
Added `GET /subscription` to retrieve a user's subscription. This includes related tests as well.

## Breaking
- [ ] Breaking changes
- [x] Non-breaking changes