### PR TITLE
feat(billing): handle successful setup intent webhook

### DIFF
--- a/packages/billing-next/__tests__/helpers/generate-fake-id.ts
+++ b/packages/billing-next/__tests__/helpers/generate-fake-id.ts
@@ -9,6 +9,8 @@ export enum IdType {
   'PRODUCT',
   'PRICE',
   'EVENT',
+  'SETUP_INTENT',
+  'PAYMENT_METHOD',
 }
 
 export function generateFakeId(idType: IdType) {
@@ -22,6 +24,8 @@ export function generateFakeId(idType: IdType) {
     4: `prod_${faker.random.alphaNumeric(24)}`,
     5: `price_${faker.random.alphaNumeric(24)}`,
     6: `evt_${faker.random.alphaNumeric(24)}`,
+    7: `seti_${faker.random.alphaNumeric(24)}`,
+    8: `pm_${faker.random.alphaNumeric(24)}`,
   };
 
   return idMapper[idType];

--- a/packages/billing-next/__tests__/post-webhook.test.ts
+++ b/packages/billing-next/__tests__/post-webhook.test.ts
@@ -289,6 +289,78 @@ describe('POST /webhook', () => {
   );
 
   test.concurrent(
+    'setup_intent.succeeded is sent -> should attach payment method to user',
+    async () => {
+      const ctx = await setup();
+      const stripe = new Stripe('', {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        apiVersion: null,
+      });
+
+      const storageAdapter = new MongooseStripeProdiverStorageAdapter(
+        ctx.mongoose,
+      );
+
+      const user = {
+        id: generateFakeId(IdType.USER),
+        stripeCustomer: generateFakeId(IdType.CUSTOMER),
+      };
+      const webhookSecret = 'whsec_T1sWT0N2rHkaFNG8EDgJfryNdlg6r2MW';
+
+      await storageAdapter.insertUser(user);
+
+      const billingServer = new BillingServer({
+        stripeSecretKey:
+          'sk_test_51LWeDVGrNXva3DrphN3qGT3dnhh2bAoNZ7O80w4XpMEbBlMeLul10aMS7a41PXZHl8vOpcDI6JZ7KoNTSBFyV9r800kV6WzTLo',
+        configFilePath: './__tests__/assets/config.json',
+        endpointSigningSecret: webhookSecret,
+        stripeProviderStorageAdapter: storageAdapter,
+        authorizationAdapter: new JwtAuthorizationAdapter({ secret: 'secret' }),
+      });
+
+      ctx.app.use(billingServer.expressMiddleware());
+
+      const expected = {
+        received: true,
+      };
+      const setupIntent = {
+        id: generateFakeId(IdType.SETUP_INTENT),
+        customer: user.stripeCustomer,
+        payment_method: generateFakeId(IdType.PAYMENT_METHOD),
+      };
+      const payload = {
+        id: generateFakeId(IdType.EVENT),
+        type: 'setup_intent.succeeded',
+        data: {
+          object: setupIntent,
+        },
+        request: {
+          idempotency_key: faker.datatype.uuid(),
+        },
+      };
+
+      const payloadString = JSON.stringify(payload, null, 2);
+      const header = stripe.webhooks.generateTestHeaderString({
+        payload: payloadString,
+        secret: webhookSecret,
+      });
+
+      await ctx.request
+        .post('/webhook')
+        .set('stripe-signature', header)
+        .send(payloadString)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data).toEqual(expected);
+        });
+
+      await teardown(ctx);
+    },
+  );
+
+  test.concurrent(
     'unhandled event -> should return 400',
     async () => {
       const ctx = await setup();

--- a/packages/billing-next/__tests__/post-webhook.test.ts
+++ b/packages/billing-next/__tests__/post-webhook.test.ts
@@ -369,16 +369,14 @@ describe('POST /webhook', () => {
       id: generateFakeId(IdType.EVENT),
       type: 'customer.subscription.updated',
       request: {
-        id: null,
         idempotency_key: faker.datatype.uuid(),
       },
     };
 
     await storageAdapter.insertEvent({
-      id: payload.id,
-      type: payload.type,
-      requestId: payload.request.id,
-      idempotencyKey: payload.request.idempotency_key,
+      stripeEvent: payload.id,
+      stripeEventType: payload.type,
+      stripeIdempotencyKey: payload.request.idempotency_key,
     });
 
     const billingServer = new BillingServer({

--- a/packages/billing-next/src/adapters/mongoose-stripe-provider-storage.adapter.ts
+++ b/packages/billing-next/src/adapters/mongoose-stripe-provider-storage.adapter.ts
@@ -129,22 +129,19 @@ export class MongooseStripeProdiverStorageAdapter
       'Event',
       new Schema<EventLog>(
         {
-          id: {
+          stripeEvent: {
             type: String,
             required: true,
             unique: true,
           },
-          type: {
+          stripeEventType: {
             type: String,
             required: true,
           },
-          idempotencyKey: {
+          stripeIdempotencyKey: {
             type: String,
             unique: true,
             required: true,
-          },
-          requestId: {
-            type: String,
           },
         },
         {
@@ -245,14 +242,14 @@ export class MongooseStripeProdiverStorageAdapter
     );
   }
 
-  async insertEvent(event: EventLog) {
+  async insertEvent(event: Omit<EventLog, 'id'>) {
     await this.#eventModel.create(event);
   }
 
   async findEvent(key: string) {
     return this.#eventModel
       .findOne({
-        $or: [{ id: key }, { idempotencyKey: key }],
+        $or: [{ stripeEvent: key }, { stripeIdempotencyKey: key }],
       })
       .lean();
   }

--- a/packages/billing-next/src/adapters/mongoose-stripe-provider-storage.adapter.ts
+++ b/packages/billing-next/src/adapters/mongoose-stripe-provider-storage.adapter.ts
@@ -81,6 +81,10 @@ export class MongooseStripeProdiverStorageAdapter
           required: true,
           unique: true,
         },
+        stripePaymentMethod: {
+          type: String,
+          unique: true,
+        },
       }),
     );
 
@@ -203,7 +207,7 @@ export class MongooseStripeProdiverStorageAdapter
   }
 
   async updateValue(id: ValueType, value: string) {
-    await this.#valueModel.findOneAndUpdate({ id }, { value });
+    await this.#valueModel.updateOne({ id }, { $set: { value } });
   }
 
   async findUser(id: string) {
@@ -216,6 +220,15 @@ export class MongooseStripeProdiverStorageAdapter
 
   async insertUser(user: User) {
     await this.#userModel.create(user);
+  }
+
+  async updateUser(id: string, user: Partial<Omit<User, 'id'>>): Promise<void> {
+    await this.#userModel.updateOne(
+      {
+        $or: [{ id }, { stripeCustomer: id }],
+      },
+      { $set: user },
+    );
   }
 
   async insertSubscription(subscription: Omit<Subscription, 'id'>) {

--- a/packages/billing-next/src/interfaces/api.provider.ts
+++ b/packages/billing-next/src/interfaces/api.provider.ts
@@ -32,7 +32,7 @@ export enum WebhookEvents {
   'SUBSCRIPTION_CREATED' = 'customer.subscription.created',
   'SUBSCRIPTION_UPDATED' = 'customer.subscription.updated',
   'SUBSCRIPTION_DELETED' = 'customer.subscription.deleted',
-  // 'PAYMENT_SUCCEEDED'
+  'SETUP_INTENT_SUCCEEDED' = 'setup_intent.succeeded',
 }
 
 export interface IApiProvider {

--- a/packages/billing-next/src/interfaces/stripe.provider.ts
+++ b/packages/billing-next/src/interfaces/stripe.provider.ts
@@ -15,6 +15,7 @@ export type Value = {
 export type User = {
   id: string;
   stripeCustomer: string;
+  stripePaymentMethod?: string;
 };
 
 export type Subscription = {
@@ -50,6 +51,7 @@ export interface IStripeProviderStorageAdapter {
   updateValue(id: ValueType, value: string): Promise<void>;
   findUser(id: string): Promise<User | null>;
   insertUser(user: User): Promise<void>;
+  updateUser(id: string, user: Partial<Omit<User, 'id'>>): Promise<void>;
   insertSubscription(subscription: Omit<Subscription, 'id'>): Promise<void>;
   findSubscriptionByUser(user: string): Promise<Subscription | null>;
   updateSubscription(

--- a/packages/billing-next/src/interfaces/stripe.provider.ts
+++ b/packages/billing-next/src/interfaces/stripe.provider.ts
@@ -34,9 +34,10 @@ export enum ValueType {
 
 export type EventLog = {
   id: string;
-  type: string;
-  idempotencyKey: string;
-  requestId: string | null;
+  stripeEvent: string;
+  stripeEventType: string;
+  stripeIdempotencyKey: string;
+  // requestId: string | null;
 };
 
 export interface IStripeProviderStorageAdapter {
@@ -55,7 +56,7 @@ export interface IStripeProviderStorageAdapter {
     id: string,
     params: Partial<Omit<Subscription, 'id'>>,
   ): Promise<void>;
-  insertEvent(event: EventLog): Promise<void>;
+  insertEvent(event: Omit<EventLog, 'id'>): Promise<void>;
   findEvent(key: string): Promise<EventLog | null>;
 }
 

--- a/packages/billing-next/src/providers/api.provider.test.ts
+++ b/packages/billing-next/src/providers/api.provider.test.ts
@@ -528,10 +528,9 @@ describe('ApiProvider', () => {
         );
         expect(StripeProviderStorageAdapterMock.insertEvent).toBeCalledWith(
           expect.objectContaining({
-            id: expect.any(String),
-            type: expect.any(String),
-            idempotencyKey: expect.any(String),
-            requestId: undefined,
+            stripeEvent: expect.any(String),
+            stripeEventType: expect.any(String),
+            stripeIdempotencyKey: expect.any(String),
           }),
         );
       },
@@ -634,10 +633,9 @@ describe('ApiProvider', () => {
         );
         expect(StripeProviderStorageAdapterMock.insertEvent).toBeCalledWith(
           expect.objectContaining({
-            id: expect.any(String),
-            type: expect.any(String),
-            idempotencyKey: expect.any(String),
-            requestId: undefined,
+            stripeEvent: expect.any(String),
+            stripeEventType: expect.any(String),
+            stripeIdempotencyKey: expect.any(String),
           }),
         );
       },
@@ -732,10 +730,9 @@ describe('ApiProvider', () => {
         );
         expect(StripeProviderStorageAdapterMock.insertEvent).toBeCalledWith(
           expect.objectContaining({
-            id: expect.any(String),
-            type: expect.any(String),
-            idempotencyKey: expect.any(String),
-            requestId: undefined,
+            stripeEvent: expect.any(String),
+            stripeEventType: expect.any(String),
+            stripeIdempotencyKey: expect.any(String),
           }),
         );
       },

--- a/packages/billing-next/src/providers/api.provider.ts
+++ b/packages/billing-next/src/providers/api.provider.ts
@@ -301,10 +301,9 @@ export class ApiProvider implements IApiProvider {
     }
 
     await this.storageAdapter.insertEvent({
-      id: event.id,
-      type: event.type,
-      idempotencyKey: event.request?.idempotency_key as string,
-      requestId: event.request?.id as string | null,
+      stripeEvent: event.id,
+      stripeEventType: event.type,
+      stripeIdempotencyKey: event.request?.idempotency_key as string,
     });
 
     return {

--- a/packages/billing-next/src/providers/api.provider.ts
+++ b/packages/billing-next/src/providers/api.provider.ts
@@ -261,6 +261,16 @@ export class ApiProvider implements IApiProvider {
         break;
       }
 
+      case WebhookEvents.SETUP_INTENT_SUCCEEDED: {
+        const setupIntent = event.data.object as Stripe.SetupIntent;
+        const { payment_method: paymentMethod, customer } = setupIntent;
+
+        await this.storageAdapter.updateUser(customer as string, {
+          stripePaymentMethod: paymentMethod as string,
+        });
+        break;
+      }
+
       case WebhookEvents.SUBSCRIPTION_UPDATED: {
         const subscription = event.data.object as Stripe.Subscription;
 

--- a/packages/billing-next/src/providers/api.provider.ts
+++ b/packages/billing-next/src/providers/api.provider.ts
@@ -180,6 +180,7 @@ export class ApiProvider implements IApiProvider {
           quantity,
         },
       ],
+      default_payment_method: customer.stripePaymentMethod,
     });
 
     return {


### PR DESCRIPTION
## Description
Handled `setup_intent.succeeded` event to attach a payment method to a user. The payment method is also set as default for charging subscriptions. This includes related tests as well.

## Breaking
- [ ] Breaking changes
- [x] Non-breaking changes