### PR TITLE
Dev/billing

### DIFF
--- a/packages/billing-next/__tests__/post-webhook.test.ts
+++ b/packages/billing-next/__tests__/post-webhook.test.ts
@@ -6,6 +6,7 @@ import { JwtAuthorizationAdapter } from '../src/adapters/jwt-authorization.adapt
 import { setup, teardown } from './fixture';
 import { generateFakeId, IdType } from './helpers/generate-fake-id';
 import { BillingServer } from '../src';
+import { Subscription } from '../src/interfaces/stripe.provider';
 
 describe('POST /webhook', () => {
   test.concurrent(
@@ -289,6 +290,81 @@ describe('POST /webhook', () => {
   );
 
   test.concurrent(
+    'invoice.paid is sent -> should set subscription as active',
+    async () => {
+      const ctx = await setup();
+      const stripe = new Stripe('', {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        apiVersion: null,
+      });
+
+      const storageAdapter = new MongooseStripeProdiverStorageAdapter(
+        ctx.mongoose,
+      );
+
+      const subscription: Omit<Subscription, 'id'> = {
+        stripeSubscription: generateFakeId(IdType.SUBSCRIPTION),
+        user: generateFakeId(IdType.USER),
+        tier: 'starter',
+        quantity: 1,
+        stripeStatus: 'incomplete',
+      };
+
+      const webhookSecret = 'whsec_T1sWT0N2rHkaFNG8EDgJfryNdlg6r2MW';
+
+      await storageAdapter.insertSubscription(subscription);
+
+      const billingServer = new BillingServer({
+        stripeSecretKey:
+          'sk_test_51LWeDVGrNXva3DrphN3qGT3dnhh2bAoNZ7O80w4XpMEbBlMeLul10aMS7a41PXZHl8vOpcDI6JZ7KoNTSBFyV9r800kV6WzTLo',
+        configFilePath: './__tests__/assets/config.json',
+        endpointSigningSecret: webhookSecret,
+        stripeProviderStorageAdapter: storageAdapter,
+        authorizationAdapter: new JwtAuthorizationAdapter({ secret: 'secret' }),
+      });
+
+      ctx.app.use(billingServer.expressMiddleware());
+
+      const expected = {
+        received: true,
+      };
+      const invoice = {
+        subscription: subscription.stripeSubscription,
+      };
+      const payload = {
+        id: generateFakeId(IdType.EVENT),
+        type: 'invoice.paid',
+        data: {
+          object: invoice,
+        },
+        request: {
+          idempotency_key: faker.datatype.uuid(),
+        },
+      };
+
+      const payloadString = JSON.stringify(payload, null, 2);
+      const header = stripe.webhooks.generateTestHeaderString({
+        payload: payloadString,
+        secret: webhookSecret,
+      });
+
+      await ctx.request
+        .post('/webhook')
+        .set('stripe-signature', header)
+        .send(payloadString)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data).toEqual(expected);
+        });
+
+      await teardown(ctx);
+    },
+    10000,
+  );
+
+  test.concurrent(
     'setup_intent.succeeded is sent -> should attach payment method to user',
     async () => {
       const ctx = await setup();
@@ -367,6 +443,7 @@ describe('POST /webhook', () => {
 
       await teardown(ctx);
     },
+    10000,
   );
 
   test.concurrent(

--- a/packages/billing-next/__tests__/post-webhook.test.ts
+++ b/packages/billing-next/__tests__/post-webhook.test.ts
@@ -327,7 +327,8 @@ describe('POST /webhook', () => {
       const setupIntent = {
         id: generateFakeId(IdType.SETUP_INTENT),
         customer: user.stripeCustomer,
-        payment_method: generateFakeId(IdType.PAYMENT_METHOD),
+        // payment_method: generateFakeId(IdType.PAYMENT_METHOD),
+        payment_method: 'samplepayment',
       };
       const payload = {
         id: generateFakeId(IdType.EVENT),
@@ -345,6 +346,14 @@ describe('POST /webhook', () => {
         payload: payloadString,
         secret: webhookSecret,
       });
+
+      nock(/stripe.com/)
+        .post(`/v1/customers/${user.stripeCustomer}`, {
+          invoice_settings: {
+            default_payment_method: setupIntent.payment_method,
+          },
+        })
+        .reply(200, {});
 
       await ctx.request
         .post('/webhook')

--- a/packages/billing-next/src/interfaces/api.provider.ts
+++ b/packages/billing-next/src/interfaces/api.provider.ts
@@ -34,6 +34,7 @@ export enum WebhookEvents {
   'SUBSCRIPTION_UPDATED' = 'customer.subscription.updated',
   'SUBSCRIPTION_DELETED' = 'customer.subscription.deleted',
   'SETUP_INTENT_SUCCEEDED' = 'setup_intent.succeeded',
+  'INVOICE_PAID' = 'invoice.paid',
 }
 
 export interface IApiProvider {

--- a/packages/billing-next/src/interfaces/api.provider.ts
+++ b/packages/billing-next/src/interfaces/api.provider.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-shadow */
+import Stripe from 'stripe';
 import { TierConfig } from '../typings';
 import { Subscription, Tier } from './stripe.provider';
 
@@ -40,7 +41,16 @@ export interface IApiProvider {
   getSecret(params: Request): Promise<Response<{ secret: string }>>;
   getSubscription(params: Request): Promise<
     Response<{
-      subscription: Omit<Subscription, 'tier'> & { tier: Tier };
+      subscription: Omit<Subscription, 'tier' | 'user'> & {
+        tier: Tier;
+        user: {
+          stripeCustomer: string;
+          paymentMethod: Pick<
+            Stripe.PaymentMethod.Card,
+            'brand' | 'country' | 'exp_month' | 'exp_year' | 'last4'
+          >;
+        };
+      };
     } | null>
   >;
   getPortal(params: Request): Promise<Response>;

--- a/packages/billing-next/src/providers/api.provider.test.ts
+++ b/packages/billing-next/src/providers/api.provider.test.ts
@@ -738,6 +738,73 @@ describe('ApiProvider', () => {
       },
     );
 
+    test.concurrent('invoice.paid -> event is handled', async () => {
+      const config = generateFakeConfig();
+
+      const container = new Container();
+
+      const invoice = {
+        subscription: generateFakeId(IdType.SUBSCRIPTION),
+      };
+
+      const StripeMock = {
+        webhooks: {
+          constructEvent: jest.fn(() => ({
+            id: generateFakeId(IdType.EVENT),
+            type: 'invoice.paid',
+            data: {
+              object: invoice,
+            },
+            request: {
+              idempotency_key: faker.datatype.uuid(),
+            },
+          })),
+        },
+      };
+
+      const StripeProviderStorageAdapterMock = {
+        findEvent: jest.fn(async () => Promise.resolve(null)),
+        updateSubscription: jest.fn(async () => Promise.resolve()),
+        insertEvent: jest.fn(async () => Promise.resolve()),
+      };
+
+      container.bind(TYPES.Stripe).toConstantValue(StripeMock);
+      container.bind(TYPES.ConfigProvider).toConstantValue({
+        config,
+      });
+      container
+        .bind(TYPES.StripeProviderStorageAdapter)
+        .toConstantValue(StripeProviderStorageAdapterMock);
+      container.bind(TYPES.ApiProvider).to(ApiProvider);
+
+      const provider = container.get<IApiProvider>(TYPES.ApiProvider);
+
+      await provider.postWebhook({
+        body: {
+          endpointSecret: '',
+          rawBody: Buffer.from(''),
+          signature: '',
+        },
+      });
+
+      expect(StripeMock.webhooks.constructEvent).toBeCalledWith(
+        expect.any(Buffer),
+        expect.any(String),
+        expect.any(String),
+      );
+      expect(StripeProviderStorageAdapterMock.findEvent).toBeCalled();
+      expect(
+        StripeProviderStorageAdapterMock.updateSubscription,
+      ).toBeCalledWith(expect.any(String), { stripeStatus: 'active' });
+      expect(StripeProviderStorageAdapterMock.insertEvent).toBeCalledWith(
+        expect.objectContaining({
+          stripeEvent: expect.any(String),
+          stripeEventType: expect.any(String),
+          stripeIdempotencyKey: expect.any(String),
+        }),
+      );
+    });
+
     test.concurrent('setup_intent.succeeded -> event is handled', async () => {
       const config = generateFakeConfig();
 

--- a/packages/billing-next/src/providers/api.provider.test.ts
+++ b/packages/billing-next/src/providers/api.provider.test.ts
@@ -762,6 +762,9 @@ describe('ApiProvider', () => {
             },
           })),
         },
+        customers: {
+          update: jest.fn(() => Promise.resolve()),
+        },
       };
 
       const StripeProviderStorageAdapterMock = {
@@ -793,6 +796,14 @@ describe('ApiProvider', () => {
         expect.any(Buffer),
         expect.any(String),
         expect.any(String),
+      );
+      expect(StripeMock.customers.update).toBeCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          invoice_settings: {
+            default_payment_method: expect.any(String),
+          },
+        }),
       );
       expect(StripeProviderStorageAdapterMock.findEvent).toBeCalled();
       expect(StripeProviderStorageAdapterMock.updateUser).toBeCalledWith(

--- a/packages/billing-next/src/providers/api.provider.ts
+++ b/packages/billing-next/src/providers/api.provider.ts
@@ -289,6 +289,17 @@ export class ApiProvider implements IApiProvider {
         break;
       }
 
+      case WebhookEvents.INVOICE_PAID: {
+        const invoice = event.data.object as Stripe.Invoice;
+        const subscription = invoice.subscription as string;
+
+        await this.storageAdapter.updateSubscription(subscription, {
+          stripeStatus: 'active',
+        });
+
+        break;
+      }
+
       case WebhookEvents.SETUP_INTENT_SUCCEEDED: {
         const setupIntent = event.data.object as Stripe.SetupIntent;
         const paymentMethod = setupIntent.payment_method as string;

--- a/packages/billing-next/src/providers/api.provider.ts
+++ b/packages/billing-next/src/providers/api.provider.ts
@@ -84,22 +84,49 @@ export class ApiProvider implements IApiProvider {
 
   async getSubscription(params: Request): Promise<
     Response<{
-      subscription: Omit<Subscription, 'tier'> & { tier: Tier };
+      subscription: Omit<Subscription, 'tier' | 'user'> & {
+        tier: Tier;
+        user: {
+          stripeCustomer: string;
+          paymentMethod: Pick<
+            Stripe.PaymentMethod.Card,
+            'brand' | 'country' | 'exp_month' | 'exp_year' | 'last4'
+          >;
+        };
+      };
     } | null>
   > {
     const { user } = params;
     const subscription = await this.storageAdapter.findSubscriptionByUser(user);
-    let data = null;
 
-    if (!R.isNil(subscription)) {
-      const tier = await this.storageAdapter.findTier(subscription.tier);
-      data = {
-        subscription: {
-          ...R.omit(['tier'], subscription),
-          tier,
-        } as Omit<Subscription, 'tier'> & { tier: Tier },
+    if (R.isNil(subscription)) {
+      return {
+        status: 200,
+        body: {
+          data: null,
+        },
       };
     }
+
+    const tier = await this.storageAdapter.findTier(subscription.tier);
+    const customer = await this.storageAdapter.findUser(user);
+    const stripePaymentMethod = await this.stripe.paymentMethods.retrieve(
+      customer?.stripePaymentMethod as string,
+    );
+
+    const data = {
+      subscription: {
+        ...R.omit(['tier', 'user'], subscription),
+        tier: tier as Tier,
+        user: {
+          stripeCustomer: customer?.stripeCustomer,
+          paymentMethod: R.pick(
+            ['brand', 'country', 'exp_month', 'exp_year', 'last4'],
+            stripePaymentMethod.card,
+          ),
+        },
+      } as never,
+    };
 
     return {
       status: 200,

--- a/packages/billing-next/src/providers/api.provider.ts
+++ b/packages/billing-next/src/providers/api.provider.ts
@@ -291,11 +291,19 @@ export class ApiProvider implements IApiProvider {
 
       case WebhookEvents.SETUP_INTENT_SUCCEEDED: {
         const setupIntent = event.data.object as Stripe.SetupIntent;
-        const { payment_method: paymentMethod, customer } = setupIntent;
+        const paymentMethod = setupIntent.payment_method as string;
+        const customer = setupIntent.customer as string;
 
-        await this.storageAdapter.updateUser(customer as string, {
-          stripePaymentMethod: paymentMethod as string,
+        await this.stripe.customers.update(customer, {
+          invoice_settings: {
+            default_payment_method: paymentMethod,
+          },
         });
+
+        await this.storageAdapter.updateUser(customer, {
+          stripePaymentMethod: paymentMethod,
+        });
+
         break;
       }
 

--- a/packages/billing-next/src/providers/stripe.provider.ts
+++ b/packages/billing-next/src/providers/stripe.provider.ts
@@ -170,6 +170,8 @@ export class StripeProvider implements IStripeProvider {
         'customer.subscription.created',
         'customer.subscription.deleted',
         'customer.subscription.updated',
+        'setup_intent.succeeded',
+        'invoice.paid',
       ],
     });
 


### PR DESCRIPTION
## Description
Handled `invoice.paid` event to attach set a subscription as active. Other changes include:
* set a user's default payment method when setup intent is successful
* added `subscription.user` that contains a user's payment details in `getSubscription` response

This includes related tests as well.

## Breaking
- [ ] Breaking changes
- [x] Non-breaking changes