### PR TITLE
feat(billing): handle invoice webhook events

### DIFF
--- a/packages/billing-next/__tests__/helpers/generate-fake-id.ts
+++ b/packages/billing-next/__tests__/helpers/generate-fake-id.ts
@@ -11,6 +11,7 @@ export enum IdType {
   'EVENT',
   'SETUP_INTENT',
   'PAYMENT_METHOD',
+  'INVOICE',
 }
 
 export function generateFakeId(idType: IdType) {
@@ -26,6 +27,7 @@ export function generateFakeId(idType: IdType) {
     6: `evt_${faker.random.alphaNumeric(24)}`,
     7: `seti_${faker.random.alphaNumeric(24)}`,
     8: `pm_${faker.random.alphaNumeric(24)}`,
+    9: `in_${faker.random.alphaNumeric(24)}`,
   };
 
   return idMapper[idType];

--- a/packages/billing-next/__tests__/post-webhook.test.ts
+++ b/packages/billing-next/__tests__/post-webhook.test.ts
@@ -532,4 +532,79 @@ describe('POST /webhook', () => {
       await teardown(ctx);
     },
   );
+
+  test.concurrent(
+    'invoice.payment_failed is sent -> should update subscription',
+    async () => {
+      const ctx = await setup();
+      const stripe = new Stripe('', {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        apiVersion: null,
+      });
+
+      const stripeProviderStorageAdapter =
+        new MongooseStripeProdiverStorageAdapter(ctx.mongoose);
+
+      const webhookSecret = 'whsec_T1sWT0N2rHkaFNG8EDgJfryNdlg6r2MW';
+      const subscription = {
+        id: generateFakeId(IdType.SUBSCRIPTION),
+      };
+
+      await stripeProviderStorageAdapter.insertSubscription({
+        stripeSubscription: subscription.id,
+        user: generateFakeId(IdType.USER),
+        tier: 'starter',
+        quantity: 1,
+        stripeStatus: 'active',
+      });
+
+      const billingServer = new BillingServer({
+        stripeSecretKey:
+          'sk_test_51LWeDVGrNXva3DrphN3qGT3dnhh2bAoNZ7O80w4XpMEbBlMeLul10aMS7a41PXZHl8vOpcDI6JZ7KoNTSBFyV9r800kV6WzTLo',
+        configFilePath: './__tests__/assets/config.json',
+        endpointSigningSecret: webhookSecret,
+        stripeProviderStorageAdapter,
+        authorizationAdapter: new JwtAuthorizationAdapter({ secret: 'secret' }),
+      });
+
+      ctx.app.use(billingServer.expressMiddleware());
+
+      const expected = {
+        received: true,
+      };
+      const invoice = {
+        id: generateFakeId(IdType.INVOICE),
+        subscription: subscription.id,
+      };
+      const payload = {
+        id: generateFakeId(IdType.EVENT),
+        type: 'invoice.payment_failed',
+        data: {
+          object: invoice,
+        },
+        request: {
+          idempotency_key: faker.datatype.uuid(),
+        },
+      };
+
+      const payloadString = JSON.stringify(payload, null, 2);
+      const header = stripe.webhooks.generateTestHeaderString({
+        payload: payloadString,
+        secret: webhookSecret,
+      });
+
+      await ctx.request
+        .post('/webhook')
+        .set('stripe-signature', header)
+        .send(payloadString)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data).toEqual(expected);
+        });
+
+      await teardown(ctx);
+    },
+  );
 });

--- a/packages/billing-next/src/interfaces/api.provider.ts
+++ b/packages/billing-next/src/interfaces/api.provider.ts
@@ -34,6 +34,7 @@ export enum WebhookEvents {
   'SUBSCRIPTION_DELETED' = 'customer.subscription.deleted',
   'SETUP_INTENT_SUCCEEDED' = 'setup_intent.succeeded',
   'INVOICE_PAID' = 'invoice.paid',
+  'INVOICE_CREATED' = 'invoice.created',
 }
 
 export interface IApiProvider {

--- a/packages/billing-next/src/interfaces/api.provider.ts
+++ b/packages/billing-next/src/interfaces/api.provider.ts
@@ -35,6 +35,7 @@ export enum WebhookEvents {
   'SETUP_INTENT_SUCCEEDED' = 'setup_intent.succeeded',
   'INVOICE_PAID' = 'invoice.paid',
   'INVOICE_CREATED' = 'invoice.created',
+  'INVOICE_PAYMENT_FAILED' = 'invoice.payment_failed',
 }
 
 export interface IApiProvider {

--- a/packages/billing-next/src/providers/api.provider.test.ts
+++ b/packages/billing-next/src/providers/api.provider.test.ts
@@ -792,6 +792,73 @@ describe('ApiProvider', () => {
       );
     });
 
+    test.concurrent('invoice.payment_failed -> event is handled', async () => {
+      const config = generateFakeConfig();
+
+      const container = new Container();
+
+      const invoice = {
+        id: generateFakeId(IdType.INVOICE),
+        subscription: generateFakeId(IdType.SUBSCRIPTION),
+      };
+
+      const StripeMock = {
+        webhooks: {
+          constructEvent: jest.fn(() => ({
+            id: generateFakeId(IdType.EVENT),
+            type: 'invoice.payment_failed',
+            data: {
+              object: invoice,
+            },
+            request: {
+              idempotency_key: faker.datatype.uuid(),
+            },
+          })),
+        },
+      };
+
+      const StripeProviderStorageAdapterMock = {
+        findEvent: jest.fn(async () => Promise.resolve(null)),
+        insertEvent: jest.fn(async () => Promise.resolve()),
+        updateSubscription: jest.fn(async () => Promise.resolve()),
+      };
+
+      container.bind(TYPES.Stripe).toConstantValue(StripeMock);
+      container.bind(TYPES.ConfigProvider).toConstantValue({
+        config,
+      });
+      container
+        .bind(TYPES.StripeProviderStorageAdapter)
+        .toConstantValue(StripeProviderStorageAdapterMock);
+      container.bind(TYPES.ApiProvider).to(ApiProvider);
+
+      const provider = container.get<IApiProvider>(TYPES.ApiProvider);
+
+      await provider.postWebhook({
+        body: {
+          endpointSecret: '',
+          rawBody: Buffer.from(''),
+          signature: '',
+        },
+      });
+
+      expect(StripeMock.webhooks.constructEvent).toBeCalledWith(
+        expect.any(Buffer),
+        expect.any(String),
+        expect.any(String),
+      );
+      expect(StripeProviderStorageAdapterMock.findEvent).toBeCalled();
+      expect(
+        StripeProviderStorageAdapterMock.updateSubscription,
+      ).toBeCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          stripeStatus: 'unpaid',
+        }),
+      );
+      expect(StripeProviderStorageAdapterMock.insertEvent).toBeCalled();
+    });
+
     test.concurrent(
       'event is already logged -> should return 200',
       async () => {

--- a/packages/billing-next/src/providers/api.provider.test.ts
+++ b/packages/billing-next/src/providers/api.provider.test.ts
@@ -731,6 +731,67 @@ describe('ApiProvider', () => {
       );
     });
 
+    test.concurrent('invoice.created -> event is handled', async () => {
+      const config = generateFakeConfig();
+
+      const container = new Container();
+
+      const invoice = {
+        id: generateFakeId(IdType.INVOICE),
+      };
+
+      const StripeMock = {
+        webhooks: {
+          constructEvent: jest.fn(() => ({
+            id: generateFakeId(IdType.EVENT),
+            type: 'invoice.created',
+            data: {
+              object: invoice,
+            },
+            request: {
+              idempotency_key: faker.datatype.uuid(),
+            },
+          })),
+        },
+        invoices: {
+          finalizeInvoice: jest.fn(() => Promise.resolve()),
+        },
+      };
+
+      const StripeProviderStorageAdapterMock = {
+        findEvent: jest.fn(async () => Promise.resolve(null)),
+        insertEvent: jest.fn(async () => Promise.resolve()),
+      };
+
+      container.bind(TYPES.Stripe).toConstantValue(StripeMock);
+      container.bind(TYPES.ConfigProvider).toConstantValue({
+        config,
+      });
+      container
+        .bind(TYPES.StripeProviderStorageAdapter)
+        .toConstantValue(StripeProviderStorageAdapterMock);
+      container.bind(TYPES.ApiProvider).to(ApiProvider);
+
+      const provider = container.get<IApiProvider>(TYPES.ApiProvider);
+
+      await provider.postWebhook({
+        body: {
+          endpointSecret: '',
+          rawBody: Buffer.from(''),
+          signature: '',
+        },
+      });
+
+      expect(StripeMock.webhooks.constructEvent).toBeCalledWith(
+        expect.any(Buffer),
+        expect.any(String),
+        expect.any(String),
+      );
+      expect(StripeMock.invoices.finalizeInvoice).toBeCalledWith(
+        expect.any(String),
+      );
+    });
+
     test.concurrent(
       'event is already logged -> should return 200',
       async () => {

--- a/packages/billing-next/src/providers/api.provider.ts
+++ b/packages/billing-next/src/providers/api.provider.ts
@@ -314,6 +314,15 @@ export class ApiProvider implements IApiProvider {
 
         break;
       }
+
+      case WebhookEvents.INVOICE_CREATED: {
+        const invoice = event.data.object as Stripe.Invoice;
+
+        await this.stripe.invoices.finalizeInvoice(invoice.id as string);
+
+        break;
+      }
+
       default:
         throw new AppError(
           'UNHANDLED_WEBHOOK_EVENT',

--- a/packages/billing-next/src/providers/api.provider.ts
+++ b/packages/billing-next/src/providers/api.provider.ts
@@ -323,6 +323,19 @@ export class ApiProvider implements IApiProvider {
         break;
       }
 
+      case WebhookEvents.INVOICE_PAYMENT_FAILED: {
+        const invoice = event.data.object as Stripe.Invoice;
+
+        await this.storageAdapter.updateSubscription(
+          invoice.subscription as string,
+          {
+            stripeStatus: 'unpaid',
+          },
+        );
+
+        break;
+      }
+
       default:
         throw new AppError(
           'UNHANDLED_WEBHOOK_EVENT',

--- a/packages/billing-next/src/providers/stripe.provider.ts
+++ b/packages/billing-next/src/providers/stripe.provider.ts
@@ -171,6 +171,7 @@ export class StripeProvider implements IStripeProvider {
         'customer.subscription.updated',
         'setup_intent.succeeded',
         'invoice.paid',
+        'invoice.created',
       ],
     });
 

--- a/packages/billing-next/src/providers/stripe.provider.ts
+++ b/packages/billing-next/src/providers/stripe.provider.ts
@@ -12,6 +12,7 @@ import {
 } from '../interfaces/stripe.provider';
 import { TYPES } from '../types';
 import { CustomerPortalConfig, TierConfig } from '../typings';
+import { WebhookEvents } from '../interfaces/api.provider';
 
 @injectable()
 export class StripeProvider implements IStripeProvider {
@@ -166,13 +167,7 @@ export class StripeProvider implements IStripeProvider {
 
     const webhookEndpoint = await this.stripe.webhookEndpoints.create({
       url: webhook.url,
-      enabled_events: [
-        'customer.subscription.deleted',
-        'customer.subscription.updated',
-        'setup_intent.succeeded',
-        'invoice.paid',
-        'invoice.created',
-      ],
+      enabled_events: Object.values(WebhookEvents),
     });
 
     await this.storageAdapter.insertValue({


### PR DESCRIPTION
## Description
Handled the following events related to invoice and subscription:
* `invoice.created` to finalize draft invoices
* `invoice.payment_failed` to update subscription as upaid

This includes related tests as well.

## Breaking
- [ ] Breaking changes
- [x] Non-breaking changes